### PR TITLE
Adding setting for alternative related field names on get_entries method

### DIFF
--- a/puput/models.py
+++ b/puput/models.py
@@ -72,7 +72,8 @@ class BlogPage(BlogRoutes, Page):
     subpage_types = ['puput.EntryPage']
 
     def get_entries(self):
-        return EntryPage.objects.descendant_of(self).live().order_by('-date').select_related('owner__username')
+        field_name = 'owner__%s' % getattr(settings, 'PUPUT_USERNAME_FIELD', 'username')
+        return EntryPage.objects.descendant_of(self).live().order_by('-date').select_related(field_name)
 
     def get_context(self, request, *args, **kwargs):
         context = super(BlogPage, self).get_context(request, *args, **kwargs)


### PR DESCRIPTION
Currently BlogPage.get_entries() relies on the username field, however this throws a FieldError exception on projects with custom user models that may not user the username field. Most of my projects use django-allauth with custom email-only authentication and as a result do not possess a username field.

I propose a PUPUT_USERNAME_FIELD setting for people with user models that don't possess the same username field in the model.