### PR TITLE
Added wagtailcore_tags to related_entries.html template

### DIFF
--- a/puput/templates/puput/related_entries.html
+++ b/puput/templates/puput/related_entries.html
@@ -1,4 +1,4 @@
-{% load i18n wagtailimages_tags puput_tags %}
+{% load i18n wagtailcore_tags wagtailimages_tags puput_tags %}
 
 <div class="row relatedPosts">
     <section class="box features">


### PR DESCRIPTION
It needs to load wagtailcore_tags for the 'richtext' filter, it was throwing TemplateSyntaxErrors at me.