### PR TITLE
Updating template tags to use django-el-pagination

### DIFF
--- a/puput/templatetags/puput_tags.py
+++ b/puput/templatetags/puput_tags.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.template import Library, loader
 
-from endless_pagination.templatetags.endless import show_pages, paginate
+from el_pagination.templatetags.el_pagination_tags import show_pages, paginate
 
 from ..urls import get_entry_url, get_feeds_url
 from ..models import Category, Tag

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     install_requires=[
         'Django>=1.7.1,<1.9',
         'wagtail>=1.0,<2.0',
-        'django-endless-pagination==2.0',
+        'django-el-pagination==2.1.1',
         'tapioca-disqus==0.1.2',
     ],
     url='http://github.com/APSL/puput',


### PR DESCRIPTION
django-el-pagination is compatible with django >= 1.9 and appears to only require a single line change in puput-tags.