### PR TITLE
Allow to place the Puput blog at any sitemap level

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Felipe Arruda
 Edu Herraiz
 David Valera
 Iker Cortabarría
+Carlos Salom

--- a/puput/feeds.py
+++ b/puput/feeds.py
@@ -3,7 +3,6 @@ from six.moves import urllib_parse
 
 from django.contrib.syndication.views import Feed
 from wagtail.wagtailcore.models import Site
-
 from .models import BlogPage
 
 
@@ -11,7 +10,7 @@ class BlogPageFeed(Feed):
 
     def __call__(self, request, *args, **kwargs):
         if request.resolver_match.url_name == 'blog_page_feed_slug':
-            self.blog_page = BlogPage.objects.get(slug=kwargs['blog_slug'])
+            self.blog_page = BlogPage.extra.get_by_path(kwargs['blog_path'])
         else:
             self.blog_page = BlogPage.objects.first()
         self.request = request
@@ -24,7 +23,7 @@ class BlogPageFeed(Feed):
         return self.blog_page.description
 
     def link(self):
-        return self.blog_page.slug
+        return self.blog_page.get_url_parts()[-1]
 
     def items(self):
         return self.blog_page.get_entries()[:20]

--- a/puput/managers.py
+++ b/puput/managers.py
@@ -2,6 +2,7 @@
 
 from django.db import models
 from django.db.models import Count
+from wagtail.wagtailcore.models import PageManager
 
 
 class TagManager(models.Manager):
@@ -16,3 +17,16 @@ class CategoryManager(models.Manager):
     def with_uses(self, blog_page):
         entries = blog_page.get_entries()
         return self.filter(entrypage__in=entries).distinct()
+
+
+class BlogManager(PageManager):
+
+    def get_by_path(self, blog_path):
+        # Look for the blog checkin all the path
+        from .models import BlogPage
+        blogs = BlogPage.objects.filter(slug=blog_path.split("/")[-1])
+        for blog in blogs:
+            if blog.url.strip("/") == blog_path:
+                return blog.specific
+        return
+

--- a/puput/models.py
+++ b/puput/models.py
@@ -19,7 +19,7 @@ from modelcluster.fields import ParentalKey
 from .abstracts import EntryAbstract
 from .utils import import_model
 from .routes import BlogRoutes
-from .managers import TagManager, CategoryManager
+from .managers import TagManager, CategoryManager, BlogManager
 
 Entry = import_model(getattr(settings, 'PUPUT_ENTRY_MODEL', EntryAbstract))
 
@@ -44,6 +44,8 @@ class BlogPage(BlogRoutes, Page):
     num_last_entries = models.IntegerField(default=3, verbose_name=_('Last entries limit'))
     num_popular_entries = models.IntegerField(default=3, verbose_name=_('Popular entries limit'))
     num_tags_entry_header = models.IntegerField(default=5, verbose_name=_('Tags limit entry header'))
+
+    extra = BlogManager()
 
     content_panels = Page.content_panels + [
         FieldPanel('description', classname="full"),
@@ -181,7 +183,7 @@ class EntryPage(Page, Entry):
 
     def get_context(self, request, *args, **kwargs):
         context = super(EntryPage, self).get_context(request, *args, **kwargs)
-        context['blog_page'] = self.blog_page
+        context['blog_page'] = self.get_parent().specific
         return context
 
     class Meta:

--- a/puput/urls.py
+++ b/puput/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
         name='entry_page_update_comments'
     ),
     url(
-        regex=r'^(?P<blog_slug>[-\w]+)/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/(?P<slug>[-\w]+)/$',
+        regex=r'^(?P<blog_path>[-\w\/]+)/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/(?P<slug>[-\w]+)/$',
         view=EntryPageServe.as_view(),
         name='entry_page_serve_slug'
     ),
@@ -23,7 +23,7 @@ urlpatterns = [
         name='entry_page_serve'
     ),
     url(
-        regex=r'^(?P<blog_slug>[-\w]+)/feed/$',
+        regex=r'^(?P<blog_path>[-\w\/]+)/feed/$',
         view=BlogPageFeed(),
         name='blog_page_feed_slug'
     ),
@@ -78,8 +78,13 @@ def get_entry_url(entry, blog_page, root_page):
             'slug': entry.slug
         })
     else:
+        # The method get_url_parts provides a tuple with a custom URL routing
+        # scheme. In the last position it finds the subdomain of the blog, which
+        # it is used to construct the entry url.
+        # Using the stripped subdomain it allows Puput to generate the urls for
+        # every sitemap level
         return reverse('entry_page_serve_slug', kwargs={
-            'blog_slug': blog_page.slug,
+            'blog_path': blog_page.get_url_parts()[-1].strip("/"),
             'year': entry.date.strftime('%Y'),
             'month': entry.date.strftime('%m'),
             'day': entry.date.strftime('%d'),
@@ -95,6 +100,6 @@ def get_feeds_url(blog_page, root_page):
     if root_page == blog_page:
         return reverse('blog_page_feed')
     else:
-        return reverse('blog_page_feed_slug', kwargs={'blog_slug': blog_page.slug})
+        return reverse('blog_page_feed_slug', kwargs={'blog_path': blog_page.get_url_parts()[-1].strip("/")})
 
 

--- a/puput/views.py
+++ b/puput/views.py
@@ -26,7 +26,17 @@ class EntryPageServe(View):
         if not request.site:
             raise Http404
         if request.resolver_match.url_name == 'entry_page_serve_slug':
-            path_components = list(operator.itemgetter(0, -1)(request.path.strip('/').split('/')))
+            # Splitting the request path and obtaining the path_components
+            # this way allows you to place the blog at the level you want on
+            # your sitemap.
+            # Example:
+            # splited_path =  ['es', 'blog', '2016', '06', '23', 'blog-entry']
+            # slicing this way you obtain:
+            # path_components =  ['es', 'blog', 'blog-entry']
+            # with the oldest solution you'll get ['es', 'blog-entry']
+            # and a 404 will be raised
+            splited_path = request.path.strip("/").split("/")
+            path_components = splited_path[:-4] + splited_path[-1:]
         else:
             path_components = [request.path.strip('/').split('/')[-1]]
         page, args, kwargs = request.site.root_page.specific.route(request, path_components)


### PR DESCRIPTION
Change the generation of the entries urls and entry_page redirection to make it possible

Entries url:
The method get_url_parts provides a tuple with a custom URL routing scheme. In the last position it finds the subdomain of the blog, which it is used to construct the entry url at  every sitemap level

Entry Page redirection:
Splitting the request path and obtaining the path_components this way allows you to place the blog at the level you want on your sitemap. 
Example: 
splited_path =  ['es', 'blog', '2016', '06', '23', 'blog-entry'] 
slicing this way you obtain: path_components =  ['es', 'blog', 'blog-entry'] 
with the oldest solution you'll get ['es', 'blog-entry'] and a 404 will be raised