### PR TITLE
Added support for using excerpt or truncated body as description of feed items

### DIFF
--- a/docs/feeds.rst
+++ b/docs/feeds.rst
@@ -1,0 +1,11 @@
+Feeds
+========
+
+Puput allows to customize the feeds for your blog entries. These options can be found in the settings tab while editing blog properties.
+
+
+Feed description
+------
+Set *Use short description in feeds* to False if you want to use the full blog post content as description for the feed items.
+When set to True (by default), Puput will try to use the blog post's excerpt or truncate the body to 70 words when the excerpt is not available.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ Contents:
    setup
    editors
    comments
+   feeds
    extending
    importers
    sites

--- a/puput/feeds.py
+++ b/puput/feeds.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from mimetypes import guess_type
 
+from django.template.defaultfilters import truncatewords_html
 from six.moves import urllib_parse
 
 from django import http
@@ -36,7 +37,15 @@ class BlogPageFeed(Feed):
     def item_title(self, item):
         return item.title
 
+    def _item_short_description(self, item):
+        if item.excerpt and item.excerpt.strip() != '':
+            return item.excerpt
+        else:
+            return truncatewords_html(item.body, 70)
+
     def item_description(self, item):
+        if self.blog_page.short_feed_description:
+            return self._item_short_description(item)
         return item.body
 
     def item_pubdate(self, item):

--- a/puput/migrations/0003_add_short_feed_description_to_blog_page.py
+++ b/puput/migrations/0003_add_short_feed_description_to_blog_page.py
@@ -1,0 +1,18 @@
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('puput', '0002_auto_20150919_0925'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='blogpage',
+            name='short_feed_description',
+            field=models.BooleanField(default=True, verbose_name='Use short description in feeds'),
+        ),
+    ]

--- a/puput/models.py
+++ b/puput/models.py
@@ -46,6 +46,8 @@ class BlogPage(BlogRoutes, Page):
     num_popular_entries = models.IntegerField(default=3, verbose_name=_('Popular entries limit'))
     num_tags_entry_header = models.IntegerField(default=5, verbose_name=_('Tags limit entry header'))
 
+    short_feed_description = models.BooleanField(default=True, verbose_name=_('Use short description in feeds'))
+
     extra = BlogManager()
 
     content_panels = Page.content_panels + [
@@ -71,6 +73,9 @@ class BlogPage(BlogRoutes, Page):
             FieldPanel('disqus_api_secret'),
             FieldPanel('disqus_shortname'),
         ], heading=_("Comments")),
+        MultiFieldPanel([
+            FieldPanel('short_feed_description'),
+        ], heading=_("Feeds")),
     ]
     subpage_types = ['puput.EntryPage']
 


### PR DESCRIPTION
addresses #93

I also added a page to document the feature, but perhaps it's better to merge that with the comments page and make it a single, more generic page?