### PR TITLE
Allow configuring custom regex for tag and category routes

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -34,3 +34,17 @@ PUPUT_USERNAME_REGEX
 
 String setting to define the default author username regex used in routes. Useful for people that are using a custom
 User model.
+
+PUPUT_TAG_REGEX
+---------------
+**Default value:** ``'[-\w]+'`` (Empty string)
+
+String setting to define the default tag regex used in routes. Useful for people that are using non-latin letters,
+digits and other symbols in tags.
+
+PUPUT_CATEGORY_REGEX
+--------------------
+**Default value:** ``'[-\w]+'`` (Empty string)
+
+String setting to define the default tag regex used in routes. Useful for people that are using non-latin letters,
+digits and other symbols in categories.

--- a/puput/routes.py
+++ b/puput/routes.py
@@ -12,6 +12,8 @@ from wagtail.wagtailcore.models import Page
 from wagtail.wagtailsearch.models import Query
 
 USERNAME_REGEX = getattr(settings, 'PUPUT_USERNAME_REGEX', '\w+')
+TAG_REGEX = getattr(settings, 'PUPUT_TAG_REGEX', '[-\w]+')
+CATEGORY_REGEX = getattr(settings, 'PUPUT_CATEGORY_REGEX', '[-\w]+')
 
 
 class BlogRoutes(RoutablePageMixin):
@@ -32,14 +34,14 @@ class BlogRoutes(RoutablePageMixin):
             self.search_term = date_format(date(int(year), int(month), int(day)))
         return Page.serve(self, request, *args, **kwargs)
 
-    @route(r'^tag/(?P<tag>[-\w]+)/$')
+    @route(r'^tag/(?P<tag>%s)/$' % TAG_REGEX)
     def entries_by_tag(self, request, tag, *args, **kwargs):
         self.search_type = _('tag')
         self.search_term = tag
         self.entries = self.get_entries().filter(tags__slug=tag)
         return Page.serve(self, request, *args, **kwargs)
 
-    @route(r'^category/(?P<category>[-\w]+)/$')
+    @route(r'^category/(?P<category>%s)/$' % CATEGORY_REGEX)
     def entries_by_category(self, request, category, *args, **kwargs):
         self.search_type = _('category')
         self.search_term = category


### PR DESCRIPTION
Backstory: I have a blog imported from Wordpress with Russian letters, spaces and digits (especially because of URL encoding) in category names and tags.
So, I think, configurable regexps for them would be good.