### PR TITLE
Owner editable

### DIFF
--- a/docs/editors.rst
+++ b/docs/editors.rst
@@ -10,3 +10,7 @@ This is how adding entry page looks:
 
 Please visit `Wagtail: an Editor’s guide <http://docs.wagtail.io/en/v1.0/editor_manual/index.html>`_ for further details
 of how to use Wagtail editor's dashboard.
+
+.. note::
+
+    If you want to edit the owner of an entry you need to install Wagtail >= 1.11.

--- a/puput/models.py
+++ b/puput/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
+from pkg_resources import parse_version
 
 from django.conf import settings
-
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.template.defaultfilters import slugify
@@ -14,6 +14,7 @@ from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 from wagtail.wagtailsnippets.models import register_snippet
 from wagtail.wagtailsearch import index
+from wagtail.wagtailcore import __version__ as WAGTAIL_VERSION
 from taggit.models import TaggedItemBase, Tag as TaggitTag
 from modelcluster.fields import ParentalKey
 
@@ -159,6 +160,19 @@ class EntryPageRelated(models.Model):
     entrypage_to = ParentalKey('EntryPage', verbose_name=_("Entry"), related_name='related_entrypage_to')
 
 
+def _add_owner_panel():
+    """
+    Since Wagtail 1.11 EntryPage owner is set as `editable` it can be added to EntryPage
+    `settings_panels` if Puput is using a version greater or equal than 1.11.
+
+    See:
+    https://github.com/wagtail/wagtail/pull/3581
+    """
+    if parse_version(WAGTAIL_VERSION) >= parse_version('1.11'):
+        return [FieldPanel('owner')]
+    return []
+
+
 class EntryPage(six.with_metaclass(PageBase, Entry, Page)):
     # Search
     search_fields = Page.search_fields + [
@@ -173,9 +187,8 @@ class EntryPage(six.with_metaclass(PageBase, Entry, Page)):
     promote_panels = Page.promote_panels + getattr(Entry, 'promote_panels', [])
 
     settings_panels = Page.settings_panels + [
-        FieldPanel('date'),
-        FieldPanel('owner'),
-    ] + getattr(Entry, 'settings_panels', [])
+        FieldPanel('date')
+    ] + _add_owner_panel() + getattr(Entry, 'settings_panels', [])
 
     # Parent and child settings
     parent_page_types = ['puput.BlogPage']
@@ -201,4 +214,3 @@ class EntryPage(six.with_metaclass(PageBase, Entry, Page)):
     class Meta:
         verbose_name = _('Entry')
         verbose_name_plural = _('Entries')
-EntryPage._meta.get_field('owner').editable = True


### PR DESCRIPTION
This fixes #107 and avoid creating undesired migrations.
Add the option to edit owner for Wagtail versions greater or equal than 1.11.