### PR TITLE
Remove django-compressor

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -38,7 +38,6 @@ If you are already referencing one of these apps in your :code:`INSTALLED_APPS` 
         'wagtail.wagtailforms',
         'wagtail.contrib.wagtailsitemaps',
         'wagtail.contrib.wagtailroutablepage',
-        'compressor',
         'taggit',
         'modelcluster',
         'puput',
@@ -115,7 +114,7 @@ If you are already referencing one of these apps in your :code:`INSTALLED_APPS` 
 Installation on top of Wagtail
 ------------------------------
 1. Install Puput and its dependencies via :code:`pip install puput`.
-2. Add :code:`puput`, :code:`compressor`, :code:`wagtail.contrib.wagtailsitemaps` and :code:`wagtail.contrib.wagtailroutablepage` to :code:`INSTALLED_APPS` in your Django settings.
+2. Add :code:`puput`, :code:`wagtail.contrib.wagtailsitemaps` and :code:`wagtail.contrib.wagtailroutablepage` to :code:`INSTALLED_APPS` in your Django settings.
 3. If you have previously defined Wagtail URLs in your patterns, set the :code:`PUPUT_AS_PLUGIN` setting to :code:`True`. This will avoid duplicate inclusion of Wagtail's URLs when you include Puput's URLs.
 4. Include Puput's URLs in your patterns **before** Wagtail's URLs.
 

--- a/puput/__init__.py
+++ b/puput/__init__.py
@@ -21,7 +21,6 @@ PUPUT_APPS = (
     'wagtail.contrib.wagtailroutablepage',
 
     # Third-party apps
-    'compressor',
     'taggit',
     'modelcluster',
 

--- a/puput/templates/puput/base.html
+++ b/puput/templates/puput/base.html
@@ -1,4 +1,4 @@
-{% load static i18n wagtailcore_tags wagtailroutablepage_tags wagtailuserbar compress puput_tags %}
+{% load static i18n wagtailcore_tags wagtailroutablepage_tags wagtailuserbar puput_tags %}
 {% wagtailuserbar %}
 <!DOCTYPE HTML>
 <html>
@@ -14,11 +14,11 @@
     <!--[if lte IE 8]><script src="assets/js/ie/html5shiv.js"></script><![endif]-->
     <!--[if lte IE 8]><link rel="stylesheet" href="assets/css/ie8.css" /><![endif]-->
     <link href='//fonts.googleapis.com/css?family=Roboto:400,300,300italic,100italic,100,400italic,500,500italic,700,900,700italic,900italic' rel='stylesheet' type='text/css'>
-    {% compress css %}
+    {% block css %}
         <link rel='stylesheet' href="{% static 'puput/css/bootstrap.min.css' %}" type='text/css'/>
         <link rel="stylesheet" href="{% static 'puput/css/font-awesome.min.css' %}">
         <link rel="stylesheet" href="{% static 'puput/css/puput.css' %}"/>
-    {% endcompress %}
+    {% endblock %}
 </head>
 <body>
 <div class="about">
@@ -101,11 +101,11 @@
         </div>
     </div>
 </div>
-{% compress js %}
+{% block js %}
     {% block extra_js %}
       <script src="{% static 'puput/js/jquery.min.js' %}"></script>
       <script src="{% static 'puput/js/puput.js' %}"></script>
     {% endblock extra_js %}
-{% endcompress js %}
+{% endblock js %}
 </body>
 </html>

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,6 @@ setup(
     install_requires=[
         # By default, pick the latest stable version of Django that's officially supported by Wagtail.
         'Django>=1.8.1,<1.12',
-
-        'django-compressor>=1.6',
         'wagtail>=1.0,<2.0',
         'django-el-pagination>=2.1.1',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,6 @@ deps =
     splinter==0.7.5
     pytest==3.0.3
     pytest-splinter==1.7.6
-    django-compressor>=1.6
     django-el-pagination>=2.1.1
     tapioca-disqus==0.1.2
     gunicorn==19.6.0


### PR DESCRIPTION
This PR remove everything about django-compressor to deploy blog simpler.you may choose other way to compress static files.
If you still want to use django-compressor,read it's doc and learn how to use it easily.Now you can compress static files freely or just don't do this.