### PR TITLE
fix el_pagination template show_pages & version in setup

### DIFF
--- a/puput/templates/el_pagination/show_pages.html
+++ b/puput/templates/el_pagination/show_pages.html
@@ -1,3 +1,3 @@
 {% for page in pages %}
-    {{ page|default_if_none:'<span class="endless_separator">...</span>' }}
+    {{ page.render_link|default:'<span class="endless_separator">...</span>' }}
 {% endfor %}

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         # By default, pick the latest stable version of Django that's officially supported by Wagtail.
         'Django>=1.8.1,<1.12',
         'wagtail>=1.0,<2.0',
-        'django-el-pagination>=2.1.1',
+        'django-el-pagination>=3.2.1',
     ],
     url='http://github.com/APSL/puput',
     author=get_author('puput'),


### PR DESCRIPTION
An update on the last release of el_pagination has broken the render of the pagination in blog page.
With this fix we ensure that the pagination is well rendered, following the instructions of el_pagination documentation.

In addition, I've change the el_pagination minor required version.