### PR TITLE
Adding support for Django 2.0 and Wagtail 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ target/
 
 # PyCharm
 .idea
+
+# Mac stuff
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,37 +3,17 @@ dist: trusty
 language: python
 matrix:
   include:
-   - env: TOXENV=py27-dj18
-     python: 2.7
-   - env: TOXENV=py34-dj18
-     python: 3.4
-   - env: TOXENV=py35-dj18
-     python: 3.5
-   - env: TOXENV=py36-dj18
-     python: 3.6
-   - env: TOXENV=py27-dj19
-     python: 2.7
-   - env: TOXENV=py34-dj19
-     python: 3.4
-   - env: TOXENV=py35-dj19
-     python: 3.5
-   - env: TOXENV=py36-dj19
-     python: 3.6
-   - env: TOXENV=py27-dj110
-     python: 2.7
-   - env: TOXENV=py34-dj110
-     python: 3.4
-   - env: TOXENV=py35-dj110
-     python: 3.5
-   - env: TOXENV=py36-dj110
-     python: 3.6
-   - env: TOXENV=py27-dj111
-     python: 2.7
    - env: TOXENV=py34-dj111
      python: 3.4
    - env: TOXENV=py35-dj111
      python: 3.5
    - env: TOXENV=py36-dj111
+     python: 3.6
+   - env: TOXENV=py34-dj20
+     python: 3.4
+   - env: TOXENV=py35-dj20
+     python: 3.5
+   - env: TOXENV=py36-dj20
      python: 3.6
    - env: TOXENV=flake8
      python: 3.5

--- a/docs/editors.rst
+++ b/docs/editors.rst
@@ -6,9 +6,9 @@ It provides a powerful, clean and modern interface. Just open your browser at ht
 
 This is how adding entry page looks:
 
-.. image:: http://i.imgur.com/NntrN3i.png
+.. image:: https://i.imgur.com/QlsVfwT.png
 
-Please visit `Wagtail: an Editor’s guide <http://docs.wagtail.io/en/v1.0/editor_manual/index.html>`_ for further details
+Please visit `Wagtail: an Editor’s guide <http://docs.wagtail.io/en/v2.0/editor_manual/index.html>`_ for further details
 of how to use Wagtail editor's dashboard.
 
 .. note::

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -25,19 +25,19 @@ If you are already referencing one of these apps in your :code:`INSTALLED_APPS` 
 
     INSTALLED_APPS = (
         ...
-        'wagtail.wagtailcore',
-        'wagtail.wagtailadmin',
-        'wagtail.wagtaildocs',
-        'wagtail.wagtailsnippets',
-        'wagtail.wagtailusers',
-        'wagtail.wagtailimages',
-        'wagtail.wagtailembeds',
-        'wagtail.wagtailsearch',
-        'wagtail.wagtailsites',
-        'wagtail.wagtailredirects',
-        'wagtail.wagtailforms',
-        'wagtail.contrib.wagtailsitemaps',
-        'wagtail.contrib.wagtailroutablepage',
+        'wagtail.core',
+        'wagtail.admin',
+        'wagtail.documents',
+        'wagtail.snippets',
+        'wagtail.users',
+        'wagtail.images',
+        'wagtail.embeds',
+        'wagtail.search',
+        'wagtail.sites',
+        'wagtail.contrib.redirects',
+        'wagtail.contrib.forms',
+        'wagtail.contrib.sitemaps',
+        'wagtail.contrib.routable_page',
         'taggit',
         'modelcluster',
         'puput',
@@ -50,8 +50,8 @@ If you are already referencing one of these apps in your :code:`INSTALLED_APPS` 
 
     MIDDLEWARE_CLASSES = (
         ...
-        'wagtail.wagtailcore.middleware.SiteMiddleware',
-        'wagtail.wagtailredirects.middleware.RedirectMiddleware',
+        'wagtail.core.middleware.SiteMiddleware',
+        'wagtail.contrib.redirects.middleware.RedirectMiddleware',
     )
 
 4. Add the :code:`request` context processor to the :code:`TEMPLATE_CONTEXT_PROCESSORS` structure in your Django settings.

--- a/puput/__init__.py
+++ b/puput/__init__.py
@@ -1,24 +1,22 @@
-# -*- coding: utf-8 -*-
-
 __author__ = 'Marc Tudurí'
 __email__ = 'marctc@gmail.com'
 __version__ = '0.9.2.1'
 
 PUPUT_APPS = (
     # Wagtail apps
-    'wagtail.wagtailcore',
-    'wagtail.wagtailadmin',
-    'wagtail.wagtaildocs',
-    'wagtail.wagtailsnippets',
-    'wagtail.wagtailusers',
-    'wagtail.wagtailimages',
-    'wagtail.wagtailembeds',
-    'wagtail.wagtailsearch',
-    'wagtail.wagtailsites',
-    'wagtail.wagtailredirects',
-    'wagtail.wagtailforms',
-    'wagtail.contrib.wagtailsitemaps',
-    'wagtail.contrib.wagtailroutablepage',
+    'wagtail.core',
+    'wagtail.admin',
+    'wagtail.documents',
+    'wagtail.snippets',
+    'wagtail.users',
+    'wagtail.images',
+    'wagtail.embeds',
+    'wagtail.search',
+    'wagtail.sites',
+    'wagtail.contrib.redirects',
+    'wagtail.contrib.forms',
+    'wagtail.contrib.sitemaps',
+    'wagtail.contrib.routable_page',
 
     # Third-party apps
     'taggit',

--- a/puput/abstracts.py
+++ b/puput/abstracts.py
@@ -50,7 +50,8 @@ class EntryAbstract(models.Model):
                 InlinePanel(
                     'related_entrypage_from',
                     label=_("Related Entries"),
-                        panels=[PageChooserPanel('entrypage_to')]),
+                    panels=[PageChooserPanel('entrypage_to')]
+                ),
             ],
             heading=_("Metadata")),
     ]

--- a/puput/abstracts.py
+++ b/puput/abstracts.py
@@ -3,11 +3,11 @@ import datetime
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from wagtail.wagtailadmin.edit_handlers import FieldPanel, InlinePanel, MultiFieldPanel, PageChooserPanel
-from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
+from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel, InlinePanel, PageChooserPanel
+from wagtail.images.edit_handlers import ImageChooserPanel
+from wagtail.core.fields import RichTextField
 
 from modelcluster.contrib.taggit import ClusterTaggableManager
-from wagtail.wagtailcore.fields import RichTextField
 
 from .utils import get_image_model_path
 
@@ -16,27 +16,43 @@ class EntryAbstract(models.Model):
     body = RichTextField(verbose_name=_('body'))
     tags = ClusterTaggableManager(through='puput.TagEntryPage', blank=True)
     date = models.DateTimeField(verbose_name=_("Post date"), default=datetime.datetime.today)
-    header_image = models.ForeignKey(get_image_model_path(), verbose_name=_('Header image'), null=True, blank=True,
-                                     on_delete=models.SET_NULL, related_name='+', )
+    header_image = models.ForeignKey(
+        get_image_model_path(),
+        verbose_name=_('Header image'),
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name='+'
+    )
     categories = models.ManyToManyField('puput.Category', through='puput.CategoryEntryPage', blank=True)
-    excerpt = RichTextField(verbose_name=_('excerpt'), blank=True,
-                            help_text=_("Entry excerpt to be displayed on entries list. "
-                                        "If this field is not filled, a truncate version of body text will be used."))
+    excerpt = RichTextField(
+        verbose_name=_('excerpt'),
+        blank=True,
+        help_text=_("Entry excerpt to be displayed on entries list. "
+                    "If this field is not filled, a truncate version of body text will be used.")
+    )
     num_comments = models.IntegerField(default=0, editable=False)
 
     content_panels = [
-        MultiFieldPanel([
-            FieldPanel('title', classname="title"),
-            ImageChooserPanel('header_image'),
-            FieldPanel('body', classname="full"),
-            FieldPanel('excerpt', classname="full"),
-        ], heading=_("Content")),
-        MultiFieldPanel([
-            FieldPanel('tags'),
-            InlinePanel('entry_categories', label=_("Categories")),
-            InlinePanel('related_entrypage_from', label=_("Related Entries"),
+        MultiFieldPanel(
+            [
+                FieldPanel('title', classname="title"),
+                ImageChooserPanel('header_image'),
+                FieldPanel('body', classname="full"),
+                FieldPanel('excerpt', classname="full"),
+            ],
+            heading=_("Content")
+        ),
+        MultiFieldPanel(
+            [
+                FieldPanel('tags'),
+                InlinePanel('entry_categories', label=_("Categories")),
+                InlinePanel(
+                    'related_entrypage_from',
+                    label=_("Related Entries"),
                         panels=[PageChooserPanel('entrypage_to')]),
-        ], heading=_("Metadata")),
+            ],
+            heading=_("Metadata")),
     ]
 
     class Meta:

--- a/puput/feeds.py
+++ b/puput/feeds.py
@@ -7,26 +7,27 @@ from django import http
 from django.contrib.syndication.views import Feed
 from django.utils.feedgenerator import Rss201rev2Feed
 from django.template.defaultfilters import truncatewords_html
+from wagtail.core.models import Site
 
-from wagtail.wagtailcore.models import Site
 from .models import BlogPage
 
 
 class BlogPageFeedGenerator(Rss201rev2Feed):
-
     def add_root_elements(self, handler):
         super(BlogPageFeedGenerator, self).add_root_elements(handler)
         if self.feed['image_link']:
-            handler.addQuickElement(u"image", '',
-                                    {
-                                        'url': self.feed['image_link'],
-                                        'title': self.feed['title'],
-                                        'link': self.feed['link'],
-                                    })
+            handler.addQuickElement(
+                u'image',
+                '',
+                {
+                    'url': self.feed['image_link'],
+                    'title': self.feed['title'],
+                    'link': self.feed['link'],
+                }
+            )
 
 
 class BlogPageFeed(Feed):
-
     feed_type = BlogPageFeedGenerator
 
     def __call__(self, request, *args, **kwargs):

--- a/puput/management/commands/puput_initial_data.py
+++ b/puput/management/commands/puput_initial_data.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
-
 from django import VERSION as DJANGO_VERSION
 from django.contrib.contenttypes.models import ContentType
 from django.core.management import BaseCommand
 
-from wagtail.wagtailcore.models import Page, Site
+from wagtail.core.models import Page, Site
 
 
 class Command(BaseCommand):

--- a/puput/managers.py
+++ b/puput/managers.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
-
 from django.db import models
 from django.db.models import Count
-from wagtail.wagtailcore.models import PageManager
+from wagtail.core.models import PageManager
+
 from .utils import strip_prefix_and_ending_slash
 
 

--- a/puput/migrations/0001_initial.py
+++ b/puput/migrations/0001_initial.py
@@ -1,13 +1,12 @@
-# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import wagtail.wagtailcore.fields
-import modelcluster.fields
+import wagtail.core.fields
 import puput.routes
 import datetime
 import django.db.models.deletion
 import modelcluster.contrib.taggit
+import modelcluster.fields
 
 
 class Migration(migrations.Migration):
@@ -21,7 +20,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='BlogPage',
             fields=[
-                ('page_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
+                ('page_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='wagtailcore.Page', on_delete=models.CASCADE)),
                 ('description', models.CharField(help_text='The page description that will appear under the title.', max_length=255, verbose_name='Description', blank=True)),
                 ('display_comments', models.BooleanField(default=False, verbose_name='Display comments')),
                 ('display_categories', models.BooleanField(default=True, verbose_name='Display categories')),
@@ -49,7 +48,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(unique=True, max_length=80, verbose_name='Category Name')),
                 ('slug', models.SlugField(unique=True, max_length=80)),
                 ('description', models.CharField(max_length=500, blank=True)),
-                ('parent', models.ForeignKey(related_name='children', blank=True, to='puput.Category', null=True)),
+                ('parent', models.ForeignKey(related_name='children', blank=True, to='puput.Category', null=True, on_delete=models.SET_NULL)),
             ],
             options={
                 'ordering': ['name'],
@@ -62,7 +61,7 @@ class Migration(migrations.Migration):
             name='CategoryEntryPage',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('category', models.ForeignKey(related_name='+', verbose_name='Category', to='puput.Category')),
+                ('category', models.ForeignKey(related_name='+', verbose_name='Category', to='puput.Category', on_delete=models.CASCADE)),
             ],
             options={
             },
@@ -71,10 +70,10 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='EntryPage',
             fields=[
-                ('page_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('body', wagtail.wagtailcore.fields.RichTextField(verbose_name='body')),
+                ('page_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='wagtailcore.Page', on_delete=models.CASCADE)),
+                ('body', wagtail.core.fields.RichTextField(verbose_name='body')),
                 ('date', models.DateTimeField(default=datetime.datetime.today, verbose_name='Post date')),
-                ('excerpt', wagtail.wagtailcore.fields.RichTextField(help_text='Used to display on puput pages list. If this field is not filled, a truncate version of body text will be used.', verbose_name='excerpt', blank=True)),
+                ('excerpt', wagtail.core.fields.RichTextField(help_text='Used to display on puput pages list. If this field is not filled, a truncate version of body text will be used.', verbose_name='excerpt', blank=True)),
                 ('num_comments', models.IntegerField(default=0, editable=False)),
                 ('categories', models.ManyToManyField(to='puput.Category', through='puput.CategoryEntryPage', blank=True)),
                 ('header_image', models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.SET_NULL, verbose_name='Header image', blank=True, to='wagtailimages.Image', null=True)),
@@ -101,7 +100,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('content_object', modelcluster.fields.ParentalKey(related_name='entry_tags', to='puput.EntryPage')),
-                ('tag', models.ForeignKey(related_name='puput_tagentrypage_items', to='taggit.Tag')),
+                ('tag', models.ForeignKey(related_name='puput_tagentrypage_items', to='taggit.Tag', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,

--- a/puput/migrations/0002_auto_20150919_0925.py
+++ b/puput/migrations/0002_auto_20150919_0925.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import wagtail.wagtailcore.fields
+import wagtail.core.fields
 
 
 class Migration(migrations.Migration):
@@ -30,11 +29,11 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='category',
             name='parent',
-            field=models.ForeignKey(to='puput.Category', related_name='children', null=True, verbose_name='Parent category', blank=True),
+            field=models.ForeignKey(to='puput.Category', related_name='children', null=True, verbose_name='Parent category', blank=True, on_delete=models.SET_NULL),
         ),
         migrations.AlterField(
             model_name='entrypage',
             name='excerpt',
-            field=wagtail.wagtailcore.fields.RichTextField(help_text='Entry excerpt to be displayed on entries list. If this field is not filled, a truncate version of body text will be used.', verbose_name='excerpt', blank=True),
+            field=wagtail.core.fields.RichTextField(help_text='Entry excerpt to be displayed on entries list. If this field is not filled, a truncate version of body text will be used.', verbose_name='excerpt', blank=True),
         ),
     ]

--- a/puput/models.py
+++ b/puput/models.py
@@ -93,7 +93,7 @@ class BlogPage(BlogRoutes, Page):
         ),
         MultiFieldPanel(
             [
-            FieldPanel('short_feed_description'),
+                FieldPanel('short_feed_description'),
             ],
             heading=_("Feeds")
         ),

--- a/puput/models.py
+++ b/puput/models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from pkg_resources import parse_version
 
 from django.conf import settings
@@ -6,15 +5,14 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.template.defaultfilters import slugify
 from django.utils.translation import ugettext_lazy as _
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils import six
 
-from wagtail.wagtailcore.models import Page, PageBase
-from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel
-from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
-from wagtail.wagtailsnippets.models import register_snippet
-from wagtail.wagtailsearch import index
-from wagtail.wagtailcore import __version__ as WAGTAIL_VERSION
+from wagtail.core.models import Page, PageBase
+from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel
+from wagtail.images.edit_handlers import ImageChooserPanel
+from wagtail.snippets.models import register_snippet
+from wagtail.search import index
+from wagtail.core import __version__ as WAGTAIL_VERSION
 from taggit.models import TaggedItemBase, Tag as TaggitTag
 from modelcluster.fields import ParentalKey
 
@@ -27,10 +25,20 @@ Entry = import_model(getattr(settings, 'PUPUT_ENTRY_MODEL', EntryAbstract))
 
 
 class BlogPage(BlogRoutes, Page):
-    description = models.CharField(verbose_name=_('Description'), max_length=255, blank=True,
-                                   help_text=_("The blog description that will appear under the title."))
-    header_image = models.ForeignKey(get_image_model_path(), verbose_name=_('Header image'), null=True, blank=True,
-                                     on_delete=models.SET_NULL, related_name='+')
+    description = models.CharField(
+        verbose_name=_('Description'),
+        max_length=255,
+        blank=True,
+        help_text=_("The blog description that will appear under the title.")
+    )
+    header_image = models.ForeignKey(
+        get_image_model_path(),
+        verbose_name=_('Header image'),
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name='+'
+    )
 
     display_comments = models.BooleanField(default=False, verbose_name=_('Display comments'))
     display_categories = models.BooleanField(default=True, verbose_name=_('Display categories'))
@@ -56,27 +64,39 @@ class BlogPage(BlogRoutes, Page):
         ImageChooserPanel('header_image'),
     ]
     settings_panels = Page.settings_panels + [
-        MultiFieldPanel([
-            FieldPanel('display_categories'),
-            FieldPanel('display_tags'),
-            FieldPanel('display_popular_entries'),
-            FieldPanel('display_last_entries'),
-            FieldPanel('display_archive'),
-        ], heading=_("Widgets")),
-        MultiFieldPanel([
-            FieldPanel('num_entries_page'),
-            FieldPanel('num_last_entries'),
-            FieldPanel('num_popular_entries'),
-            FieldPanel('num_tags_entry_header'),
-        ], heading=_("Parameters")),
-        MultiFieldPanel([
-            FieldPanel('display_comments'),
-            FieldPanel('disqus_api_secret'),
-            FieldPanel('disqus_shortname'),
-        ], heading=_("Comments")),
-        MultiFieldPanel([
+        MultiFieldPanel(
+            [
+                FieldPanel('display_categories'),
+                FieldPanel('display_tags'),
+                FieldPanel('display_popular_entries'),
+                FieldPanel('display_last_entries'),
+                FieldPanel('display_archive'),
+            ],
+            heading=_("Widgets")
+        ),
+        MultiFieldPanel(
+            [
+                FieldPanel('num_entries_page'),
+                FieldPanel('num_last_entries'),
+                FieldPanel('num_popular_entries'),
+                FieldPanel('num_tags_entry_header'),
+            ],
+            heading=_("Parameters")
+        ),
+        MultiFieldPanel(
+            [
+                FieldPanel('display_comments'),
+                FieldPanel('disqus_api_secret'),
+                FieldPanel('disqus_shortname'),
+            ],
+            heading=_("Comments")
+        ),
+        MultiFieldPanel(
+            [
             FieldPanel('short_feed_description'),
-        ], heading=_("Feeds")),
+            ],
+            heading=_("Feeds")
+        ),
     ]
     subpage_types = ['puput.EntryPage']
 
@@ -103,12 +123,17 @@ class BlogPage(BlogRoutes, Page):
 
 
 @register_snippet
-@python_2_unicode_compatible
 class Category(models.Model):
     name = models.CharField(max_length=80, unique=True, verbose_name=_('Category name'))
     slug = models.SlugField(unique=True, max_length=80)
-    parent = models.ForeignKey('self', blank=True, null=True, related_name="children",
-                               verbose_name=_('Parent category'))
+    parent = models.ForeignKey(
+        'self',
+        blank=True,
+        null=True,
+        related_name="children",
+        verbose_name=_('Parent category'),
+        on_delete=models.SET_NULL
+    )
     description = models.CharField(max_length=500, blank=True, verbose_name=_('Description'))
 
     objects = CategoryManager()
@@ -136,7 +161,7 @@ class Category(models.Model):
 
 
 class CategoryEntryPage(models.Model):
-    category = models.ForeignKey(Category, related_name="+", verbose_name=_('Category'))
+    category = models.ForeignKey(Category, related_name="+", verbose_name=_('Category'), on_delete=models.CASCADE)
     page = ParentalKey('EntryPage', related_name='entry_categories')
     panels = [
         FieldPanel('category')

--- a/puput/routes.py
+++ b/puput/routes.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from datetime import date
 
 from django.utils.dateformat import DateFormat
@@ -7,9 +5,9 @@ from django.utils.formats import date_format
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 
-from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin, route
-from wagtail.wagtailcore.models import Page
-from wagtail.wagtailsearch.models import Query
+from wagtail.contrib.routable_page.models import RoutablePageMixin, route
+from wagtail.core.models import Page
+from wagtail.search.models import Query
 
 USERNAME_REGEX = getattr(settings, 'PUPUT_USERNAME_REGEX', '\w+')
 

--- a/puput/templates/el_pagination/page_link.html
+++ b/puput/templates/el_pagination/page_link.html
@@ -1,3 +1,5 @@
 <a href="{{ page.path }}"
-    rel="{{ querystring_key }}{% if add_nofollow %} nofollow{% endif %}"
-    class="endless_page_link">{{ page.label|safe }}</a>
+   rel="{{ querystring_key }}{% if add_nofollow %} nofollow{% endif %}"
+   class="endless_page_link">
+    {{ page.label|safe }}
+</a>

--- a/puput/templates/puput/base.html
+++ b/puput/templates/puput/base.html
@@ -3,11 +3,25 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-    <title>{% block title %}{{ blog_page.title }}{% if blog_page.description %} | {{ blog_page.description }}{% endif %}{% endblock title %}</title>
+    <title>
+        {% block title %}
+            {{ blog_page.title }}{% if blog_page.description %} | {{ blog_page.description }}{% endif %}
+        {% endblock title %}
+    </title>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <meta name="title" content="{% block meta_title %}{% if blog_page.seo_title %}{{ blog_page.seo_title }}{% else %}{{ blog_page.title }}{% endif %}{% endblock meta_title %}"/>
-    <meta name="description" content="{% block meta_description %}{{ blog_page.search_description }}{% endblock meta_description %}"/>
+    <meta name="title"
+          content="{% block meta_title %}
+                        {% if blog_page.seo_title %}
+                            {{ blog_page.seo_title }}
+                        {% else %}
+                            {{ blog_page.title }}
+                        {% endif %}
+                   {% endblock meta_title %}"/>
+    <meta name="description"
+          content="{% block meta_description %}
+                        {{ blog_page.search_description }}
+                   {% endblock meta_description %}"/>
     {% block social_share %}{% endblock social_share %}
     <link rel="canonical" href="{% block canonical %}{% canonical_url %}{% endblock canonical %}"/>
 

--- a/puput/templates/puput/blog_page.html
+++ b/puput/templates/puput/blog_page.html
@@ -2,19 +2,40 @@
 
 {% load static i18n wagtailcore_tags wagtailimages_tags puput_tags %}
 
-{% block title %}{% if search_term %}{{ search_term }} | {{ blog_page.title }}{% else %}{{ block.super }}{% endif %}{% endblock title %}
-{% block meta_title %}{% if search_term %}{% trans 'Entries for' %} {{ search_type }} {{ search_term }}{% else %}{{ block.super }}{% endif %}{% endblock meta_title %}
-{% block meta_description %}{% if search_term %}{% trans 'Entries for' %} {{ search_type }} {{ search_term }}{% else %}{{ block.super }}{% endif %}{% endblock meta_description %}
+{% block title %}
+    {% if search_term %}
+        {{ search_term }} | {{ blog_page.title }}
+    {% else %}
+        {{ block.super }}
+    {% endif %}
+{% endblock title %}
+
+{% block meta_title %}
+    {% if search_term %}
+        {% trans 'Entries for' %} {{ search_type }} {{ search_term }}
+    {% else %}
+        {{ block.super }}
+    {% endif %}
+{% endblock meta_title %}
+
+{% block meta_description %}
+    {% if search_term %}
+        {% trans 'Entries for' %} {{ search_type }} {{ search_term }}
+    {% else %}
+        {{ block.super }}
+    {% endif %}
+{% endblock meta_description %}
+
 {% block social_share %}
     {% image blog_page.header_image fill-800x450 as share_image %}
     <meta property="og:title" content="{{ blog_page.title }}" />
     <meta property="og:description" content="{{ blog_page.description }}" />
     <meta property="og:url" content="{% canonical_url %}" />
     {% if blog_page.header_image %}
-    <meta property="og:image" content="{% image_url share_image.url %}" />
-    <meta property="og:image:width" content="800" />
-    <meta property="og:image:height" content="450" />
-    <meta name="twitter:image" content="{% image_url share_image.url %}" />
+        <meta property="og:image" content="{% image_url share_image.url %}" />
+        <meta property="og:image:width" content="800" />
+        <meta property="og:image:height" content="450" />
+        <meta name="twitter:image" content="{% image_url share_image.url %}" />
     {% endif %}
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="{{ blog_page.title }}" />

--- a/puput/templates/puput/entry_page.html
+++ b/puput/templates/puput/entry_page.html
@@ -1,20 +1,40 @@
 {% extends "puput/base.html" %}
 {% load wagtailcore_tags wagtailimages_tags puput_tags %}
 
-{% block title %}{{ self.title }} | {{ blog_page.title }}{% endblock title %}
-{% block meta_title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}{% endblock meta_title %}
-{% block meta_description %}{% if self.search_description %}{{ self.search_description }}{% else %}{{ self.body|striptags|truncatewords:20 }}{% endif %}{% endblock meta_description %}
-{% block canonical %}{% canonical_url entry=self %}{% endblock canonical %}
+{% block title %}
+    {{ self.title }} | {{ blog_page.title }}
+{% endblock title %}
+
+{% block meta_title %}
+    {% if self.seo_title %}
+        {{ self.seo_title }}
+    {% else %}
+        {{ self.title }}
+    {% endif %}
+{% endblock meta_title %}
+
+{% block meta_description %}
+    {% if self.search_description %}
+        {{ self.search_description }}
+    {% else %}
+        {{ self.body|striptags|truncatewords:20 }}
+    {% endif %}
+{% endblock meta_description %}
+
+{% block canonical %}
+    {% canonical_url entry=self %}
+{% endblock canonical %}
+
 {% block social_share %}
     {% image self.header_image fill-800x450 as share_image %}
     <meta property="og:title" content="{{ self.title }}" />
     <meta property="og:description" content="{% if self.excerpt %}{{ self.excerpt|striptags }}{% else %}{{ self.body|striptags|truncatewords:20 }}{% endif %}" />
     <meta property="og:url" content="{% canonical_url entry=self %}" />
     {% if self.header_image %}
-    <meta property="og:image" content="{% image_url share_image.url %}" />
-    <meta property="og:image:width" content="800" />
-    <meta property="og:image:height" content="450" />
-    <meta name="twitter:image" content="{% image_url share_image.url %}" />
+        <meta property="og:image" content="{% image_url share_image.url %}" />
+        <meta property="og:image:width" content="800" />
+        <meta property="og:image:height" content="450" />
+        <meta name="twitter:image" content="{% image_url share_image.url %}" />
     {% endif %}
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="{{ self.title }}" />

--- a/puput/templatetags/puput_tags.py
+++ b/puput/templatetags/puput_tags.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 from django.template import Library
-from django.core.urlresolvers import resolve
+from django.urls import resolve
 from django.template.loader import render_to_string
 
 from el_pagination.templatetags.el_pagination_tags import show_pages, paginate
@@ -95,6 +94,7 @@ def show_comments(context):
         }
         return render_to_string('puput/comments/disqus.html', context=ctx)
     return ""
+
 
 # Avoid to import endless_pagination in installed_apps and in the templates
 register.tag('show_paginator', show_pages)

--- a/puput/urls.py
+++ b/puput/urls.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.conf.urls import url, include
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from .feeds import BlogPageFeed
 from .views import EntryPageServe, EntryPageUpdateCommentsView
@@ -36,11 +36,11 @@ urlpatterns = [
 ]
 
 if not getattr(settings, 'PUPUT_AS_PLUGIN', False):
-    from wagtail.wagtailcore import urls as wagtail_urls
-    from wagtail.wagtailadmin import urls as wagtailadmin_urls
-    from wagtail.wagtaildocs import urls as wagtaildocs_urls
-    from wagtail.wagtailsearch import urls as wagtailsearch_urls
-    from wagtail.contrib.wagtailsitemaps.views import sitemap
+    from wagtail.core import urls as wagtail_urls
+    from wagtail.admin import urls as wagtailadmin_urls
+    from wagtail.documents import urls as wagtaildocs_urls
+    from wagtail.search import urls as wagtailsearch_urls
+    from wagtail.contrib.sitemaps.views import sitemap
 
     urlpatterns.extend([
         url(

--- a/puput/utils.py
+++ b/puput/utils.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
-
 from six import string_types
 from importlib import import_module
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 
 def import_model(path_or_callable):

--- a/puput/views.py
+++ b/puput/views.py
@@ -3,7 +3,7 @@ from django.views.generic import View
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.utils.decorators import method_decorator
 
-from wagtail.wagtailcore import hooks
+from wagtail.core import hooks
 
 from .comments import get_num_comments_with_disqus
 from .models import EntryPage

--- a/puput/wagtail_hooks.py
+++ b/puput/wagtail_hooks.py
@@ -1,0 +1,62 @@
+import wagtail.admin.rich_text.editors.draftail.features as draftail_features
+from wagtail.admin.rich_text.converters.html_to_contentstate import InlineStyleElementHandler, BlockElementHandler
+from wagtail.core import hooks
+
+
+@hooks.register('register_rich_text_features')
+def register_blockquote_feature(features):
+    """
+    Registering the `blockquote` feature, which uses the `blockquote` Draft.js block type,
+    and is stored as HTML with a `<blockquote>` tag.
+    """
+    feature_name = 'blockquote'
+    type_ = 'blockquote'
+    tag = 'blockquote'
+
+    control = {
+        'type': type_,
+        'label': '❝',
+        'description': 'Quote',
+        'element': 'blockquote',
+    }
+
+    features.register_editor_plugin(
+        'draftail',
+        feature_name,
+        draftail_features.BlockFeature(control)
+    )
+
+    features.register_converter_rule(
+        'contentstate',
+        feature_name,
+        {
+            'from_database_format': {tag: BlockElementHandler(type_)},
+            'to_database_format': {'block_map': {type_: tag}},
+        }
+    )
+    features.default_features.append(feature_name)
+
+
+@hooks.register('register_rich_text_features')
+def register_codeline_feature(features):
+    feature_name = 'Code Line'
+    type_ = 'CODE'
+    tag = 'code'
+
+    control = {
+        'type': type_,
+        'label': '>_',
+        'description': 'Code Line',
+    }
+
+    features.register_editor_plugin(
+        'draftail', feature_name, draftail_features.InlineStyleFeature(control)
+    )
+
+    db_conversion = {
+        'from_database_format': {tag: InlineStyleElementHandler(type_)},
+        'to_database_format': {'style_map': {type_: tag}},
+    }
+
+    features.register_converter_rule('contentstate', feature_name, db_conversion)
+    features.default_features.append(feature_name)

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,8 @@ setup(
     long_description=codecs.open(os.path.join(os.path.dirname(__file__), 'README.rst'), encoding='utf-8').read(),
     install_requires=[
         # By default, pick the latest stable version of Django that's officially supported by Wagtail.
-        'Django>=1.8.1,<1.12',
-        'wagtail>=1.0,<2.0',
+        'Django>=1.11,<2.1',
+        'wagtail>=1.0,<2.1',
         'django-el-pagination>=3.2.1',
     ],
     url='http://github.com/APSL/puput',
@@ -53,8 +53,6 @@ setup(
         'Framework :: Django',
         'Intended Audience :: Developers',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -8,7 +8,6 @@ DEBUG = True
 ALLOWED_HOSTS = "*"
 
 INSTALLED_APPS = (
-    'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -26,8 +25,8 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
-    'wagtail.wagtailcore.middleware.SiteMiddleware',
-    'wagtail.wagtailredirects.middleware.RedirectMiddleware',
+    'wagtail.core.middleware.SiteMiddleware',
+    'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 )
 
 ROOT_URLCONF = 'tests.testapp.urls'

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -16,15 +16,14 @@ INSTALLED_APPS = (
 )
 INSTALLED_APPS += PUPUT_APPS
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
+    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.security.SecurityMiddleware',
     'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 )

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -1,10 +1,8 @@
 from django.conf import settings
 from django.conf.urls import include, url
-from django.contrib import admin
 from django.conf.urls.static import static
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
     url(r'', include('puput.urls')),
 ]
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36}-dj{18,19,110,111}, flake8
+envlist = py{34,35,36}-dj{111,20}, flake8
 
 [flake8]
 max-line-length = 120
@@ -15,7 +15,6 @@ commands =
    pytest --splinter-webdriver=remote --splinter-remote-url=http://localhost:4444/wd/hub --site-url=http://172.17.0.1:8000
 
 basepython =
-    py27: python2.7
     py34: python3.4
     py35: python3.5
     py36: python3.6
@@ -29,10 +28,8 @@ deps =
     tapioca-disqus==0.1.2
     gunicorn==19.6.0
 
-    dj18: Django>=1.8.1,<1.9
-    dj19: Django>=1.9,<1.10
-    dj110: Django>=1.10,<1.11
     dj111: Django>=1.11,<1.12
+    dj20: Django>=2.0,<2.1
 
 [testenv:flake8]
 basepython = python3.5


### PR DESCRIPTION
This PR enables the support for Wagtail 2.0, I've tested almost all the features in a test blog I have and it seemed to be working fine.

For now there's no support for highlighted code blocks for Draftail in this PR but I'm in contact with some of the Wagtail's core devs and they suggested to me to develop that feature as a separated package which could be added to Wagtail's core in the future, so that's my next step and after that I'll be adding that feature here in Pupput.

Also, for now I've added Blockquotes and Code Lines (like this -> `this_is_a_method()`) support for the Puput's Draftail, let me know if there is another Inline or Block feature you want us to support here.