### PR TITLE
Blog header image usage

### DIFF
--- a/puput/static/puput/css/puput.css
+++ b/puput/static/puput/css/puput.css
@@ -228,8 +228,19 @@ p {
     padding: 30px 0 20px;
 }
 
+.about .title-section-image {
+    padding: 0;
+}
+
 .about .title-section h1 {
     font-weight: 400;
+}
+
+
+.about .title-section-image h1 {
+    margin-top: 0;
+    font-weight: 400;
+    font-size: 30px;
 }
 
 .about .title-section h2 {

--- a/puput/templates/puput/base.html
+++ b/puput/templates/puput/base.html
@@ -1,4 +1,4 @@
-{% load static i18n wagtailcore_tags wagtailroutablepage_tags wagtailuserbar puput_tags %}
+{% load static i18n wagtailcore_tags wagtailimages_tags wagtailroutablepage_tags wagtailuserbar puput_tags %}
 <!DOCTYPE HTML>
 <html>
 <head>
@@ -41,12 +41,20 @@
 <body>
 {% block blog_header %}
     <div class="about">
+        {% if blog_page.header_image %}
+            <span class="image featured">
+                {% image blog_page.header_image fill-1500x120 as header_image %}
+                <img alt="{{ blog_page.header_image.title }}" src="{{ header_image.url }}">
+            </span>
+        {% endif %}
         <div class="container">
-            <section class="title-section">
+            <section class="{% if blog_page.header_image %}title-section-image{% else %}title-section{% endif %}">
                 <h1 class="title-header">
                     <a href="{% pageurl blog_page %}">{{ blog_page.title }}</a>
                 </h1>
-                <h2>{{ blog_page.description }}</h2>
+                {% if not blog_page.header_image %}
+                    <h2>{{ blog_page.description }}</h2>
+                {% endif %}
             </section>
         </div>
     </div>


### PR DESCRIPTION
Changes in blog header in order to use the blog header's image.
An example is porvided:
![blog-header-image-example](https://user-images.githubusercontent.com/16468446/38771113-3ad7a164-401d-11e8-964d-0d12a142c79e.png)
