### PR TITLE
Add CategoryEntryPage & EntryPageRelated __str__

### DIFF
--- a/puput/models.py
+++ b/puput/models.py
@@ -172,6 +172,9 @@ class CategoryEntryPage(models.Model):
         FieldPanel('category')
     ]
 
+    def __str__(self):
+        return str(self.category)
+
 
 class TagEntryPage(TaggedItemBase):
     content_object = ParentalKey('EntryPage', related_name='entry_tags')
@@ -188,6 +191,9 @@ class Tag(TaggitTag):
 class EntryPageRelated(models.Model):
     entrypage_from = ParentalKey('EntryPage', verbose_name=_("Entry"), related_name='related_entrypage_from')
     entrypage_to = ParentalKey('EntryPage', verbose_name=_("Entry"), related_name='related_entrypage_to')
+
+    def __str__(self):
+        return str(self.entrypage_to)
 
 
 def _add_owner_panel():


### PR DESCRIPTION
Adds `__str__()` methods to `CategoryEntryPage` and `EntryPageRelated`.

This improves Puput's integration with `wagtail-condensedinlinepanel`. It will result in a performance hit when displaying these model instances as strings since the `__str__()` method depends on a foreign key, but it will be negligible.

Before:
![screenshot from 2018-04-23 17-49-24](https://user-images.githubusercontent.com/1728528/39159027-bddb43a4-4739-11e8-92bf-5bbdcd52fef8.png)

After:
![screenshot from 2018-04-23 17-48-51](https://user-images.githubusercontent.com/1728528/39159035-c429e7ec-4739-11e8-99df-0247efb99505.png)
