### PR TITLE
update requirements in setup.py and tox.ini

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     install_requires=[
         # By default, pick the latest stable version of Django that's officially supported by Wagtail.
         'Django>=1.11,<2.1',
-        'wagtail>=1.0,<2.1',
+        'wagtail>=1.0,<=2.1',
         'django-el-pagination>=3.2.1',
         'django-social-share>=1.1.2',
         'django-colorful>=1.2'

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,9 @@ deps =
     splinter==0.7.5
     pytest==3.0.3
     pytest-splinter==1.7.6
-    django-el-pagination>=2.1.1
+    django-el-pagination>=3.2.1
+    django-social-share>=1.1.2
+    django-colorful>=1.2
     tapioca-disqus==0.1.2
     gunicorn==19.6.0
 


### PR DESCRIPTION
Two changes are proposed:
* in setup.py: update the compatible wagtail versions
* in tox.ini: add the new dependencies (django-social-share and django-colorful) and update the django-el-pagination dependency