### PR TITLE
Update documentation setup getting error

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -93,6 +93,7 @@ If you are already referencing one of these apps in your :code:`INSTALLED_APPS` 
 
 
     from django.conf import settings
+    from django.conf.urls import url
 
     if settings.DEBUG:
         import os
@@ -103,7 +104,7 @@ If you are already referencing one of these apps in your :code:`INSTALLED_APPS` 
         urlpatterns += staticfiles_urlpatterns() # tell gunicorn where static files are in dev mode
         urlpatterns += static(settings.MEDIA_URL + 'images/', document_root=os.path.join(settings.MEDIA_ROOT, 'images'))
         urlpatterns += [
-            (r'^favicon\.ico$', RedirectView.as_view(url=settings.STATIC_URL + 'myapp/images/favicon.ico')),
+            url(r'^favicon\.ico$', RedirectView.as_view(url=settings.STATIC_URL + 'myapp/images/favicon.ico')),
         ]
 
 


### PR DESCRIPTION
"To simplify URL configs, patterns() was deprecated in Django 1.8, and removed in 1.10 (release notes). In Django 1.10, urlpatterns must be a list of url() instances. Using a tuple in patterns() is not supported any more, and the Django checks framework will raise an error."

Source: https://stackoverflow.com/questions/38786461/django-error-your-url-pattern-is-invalid-ensure-that-urlpatterns-is-a-list-of

Error log:

> (urls.E004) Your URL pattern ('^favicon\\.ico$', <function RedirectView at 0x11283a9d8>) is invalid. Ensure that urlpatterns is a list of path() and/or re_path() instances.
>        HINT: Try using path() instead of a tuple.`