### PR TITLE
documentation for installation on top of Wagtail

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -116,19 +116,21 @@ If you are already referencing one of these apps in your :code:`INSTALLED_APPS` 
 Installation on top of Wagtail
 ------------------------------
 0. This assumes that you have Wagtail >= 2.0 installed and you can access /admin; if this is not the case or you would like to use a newer version of Wagtail than is in the dependencies of puput, follow the steps below in a python venv:
+
 .. code-block:: bash
 
-pip install --upgrade pip
-pip install wheel
-pip install wagtail django-colorful django-el-pagination django-social-share
-pip install --no-deps puput
-wagtail start mysite
-cd mysite
-python manage.py migrate
-python manage.py createsuperuser
+    pip install --upgrade pip
+    pip install wheel
+    pip install wagtail django-colorful django-el-pagination django-social-share
+    pip install --no-deps puput
+    wagtail start mysite
+    cd mysite
+    python manage.py migrate
+    python manage.py createsuperuser
 
 1. If you haven't already, install Puput and its dependencies via :code:`pip install puput`.
 2. In your Django settings (most commonly settings/base.py inside the wagtail directory), add the following to the `INSTALLED_APPS` following the wagtail section:
+
 .. code-block:: python
  
      'wagtail.contrib.sitemaps',
@@ -136,9 +138,13 @@ python manage.py createsuperuser
      'django_social_share',
      'puput',
      'colorful',
+
 3. In the same file, also add the line `PUPUT_AS_PLUGIN = True` to the very bottom
+
 4. In the same folder, add to `urls.py` near the top `from puput import urls as puput_urls` and just above `url(r'', include(wagtail_urls)),` add `url(r'',include(puput_urls)),`
+
 5. Run :code:`python manage.py migrate` followed by `python manage.py runserver 0:8000` to start the server
+
 6. To create a Puput blog navigate to the Wagtail admin interface at `127.0.0.1:8000/admin` and create a new child page of type `Blog`. Every blog post is then created as a child of this blog.
 
 Docker

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -115,21 +115,31 @@ If you are already referencing one of these apps in your :code:`INSTALLED_APPS` 
 
 Installation on top of Wagtail
 ------------------------------
-1. Install Puput and its dependencies via :code:`pip install puput`.
-2. Add :code:`puput`, :code:`wagtail.contrib.sitemaps` and :code:`wagtail.contrib.routable_page` and :code:`django_social_share` to :code:`INSTALLED_APPS` in your Django settings.
-3. If you have previously defined Wagtail URLs in your patterns, set the :code:`PUPUT_AS_PLUGIN` setting to :code:`True`. This will avoid duplicate inclusion of Wagtail's URLs when you include Puput's URLs.
-4. Include Puput's URLs in your patterns **before** Wagtail's URLs.
+0. This assumes that you have Wagtail >= 2.0 installed and you can access /admin; if this is not the case or you would like to use a newer version of Wagtail than is in the dependencies of puput, follow the steps below in a python venv:
+.. code-block:: bash
 
+pip install --upgrade pip
+pip install wheel
+pip install wagtail django-colorful django-el-pagination django-social-share
+pip install --no-deps puput
+wagtail start mysite
+cd mysite
+python manage.py migrate
+python manage.py createsuperuser
+
+1. If you haven't already, install Puput and its dependencies via :code:`pip install puput`.
+2. In your Django settings (most commonly settings/base.py inside the wagtail directory), add the following to the `INSTALLED_APPS` following the wagtail section:
 .. code-block:: python
-
-    urlpatterns = [
-        ...
-        url(r'', include('puput.urls')),
-        url(r'', include(wagtail_urls)),
-    ]
-
-5. Run :code:`python manage.py migrate`.
-
+ 
+     'wagtail.contrib.sitemaps',
+     'wagtail.contrib.routable_page',
+     'django_social_share',
+     'puput',
+     'colorful',
+3. In the same file, also add the line `PUPUT_AS_PLUGIN = True` to the very bottom
+4. In the same folder, add to `urls.py` near the top `from puput import urls as puput_urls` and just above `url(r'', include(wagtail_urls)),` add `url(r'',include(puput_urls)),`
+5. Run :code:`python manage.py migrate` followed by `python manage.py runserver 0:8000` to start the server
+6. To create a Puput blog navigate to the Wagtail admin interface at `127.0.0.1:8000/admin` and create a new child page of type `Blog`. Every blog post is then created as a child of this blog.
 
 Docker
 ------

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -129,7 +129,7 @@ Installation on top of Wagtail
     python manage.py createsuperuser
 
 1. If you haven't already, install Puput and its dependencies via :code:`pip install puput`.
-2. In your Django settings (most commonly settings/base.py inside the wagtail directory), add the following to the `INSTALLED_APPS` following the wagtail section:
+2. In your Django settings (most commonly settings/base.py inside the wagtail directory), add the following to the :code:`INSTALLED_APPS` following the wagtail section:
 
 .. code-block:: python
  
@@ -139,13 +139,13 @@ Installation on top of Wagtail
      'puput',
      'colorful',
 
-3. In the same file, also add the line `PUPUT_AS_PLUGIN = True` to the very bottom
+3. In the same file, also add the line :code:`PUPUT_AS_PLUGIN = True` to the very bottom
 
-4. In the same folder, add to `urls.py` near the top `from puput import urls as puput_urls` and just above `url(r'', include(wagtail_urls)),` add `url(r'',include(puput_urls)),`
+4. In the same folder, add to :code:`urls.py` near the top :code:`from puput import urls as puput_urls` and just above :code:`url(r'', include(wagtail_urls)),` add :code:`url(r'',include(puput_urls)),`
 
-5. Run :code:`python manage.py migrate` followed by `python manage.py runserver 0:8000` to start the server
+5. Run :code:`python manage.py migrate` followed by :code:`python manage.py runserver 0:8000` to start the server
 
-6. To create a Puput blog navigate to the Wagtail admin interface at `127.0.0.1:8000/admin` and create a new child page of type `Blog`. Every blog post is then created as a child of this blog.
+6. To create a Puput blog navigate to the Wagtail admin interface at :code:`127.0.0.1:8000/admin` and create a new child page of type :code:`Blog`. Every blog post is then created as a child of this blog.
 
 Docker
 ------


### PR DESCRIPTION
concerning documentation for `Installation on top of Wagtail`:

- added an extra step to help beginners in installing puput and wagtail. This step is compatible with Wagtail-2.2 despite what puput has a dependency in pip
- fixed a few mistakes in the installation process
- in its current state, the documentation can be used step by step to create a functioning puput blog from scratch on Wagtail-2.2