### PR TITLE
Django URLS upgrading to 2.0 and Wagtail 2.3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ dist: trusty
 language: python
 matrix:
   include:
-   - env: TOXENV=py34-dj111
-     python: 3.4
-   - env: TOXENV=py35-dj111
-     python: 3.5
-   - env: TOXENV=py36-dj111
-     python: 3.6
    - env: TOXENV=py34-dj20
      python: 3.4
    - env: TOXENV=py35-dj20
@@ -18,7 +12,7 @@ matrix:
    - env: TOXENV=py34-dj21
      python: 3.4
    - env: TOXENV=py35-dj21
-     python: 3.6
+     python: 3.5
    - env: TOXENV=py36-dj21
      python: 3.6
    - env: TOXENV=flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ matrix:
      python: 3.5
    - env: TOXENV=py36-dj20
      python: 3.6
+   - env: TOXENV=py34-dj21
+     python: 3.4
+   - env: TOXENV=py35-dj21
+     python: 3.6
    - env: TOXENV=py36-dj21
      python: 3.6
    - env: TOXENV=flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
      python: 3.5
    - env: TOXENV=py36-dj20
      python: 3.6
+   - env: TOXENV=py36-dj21
+     python: 3.6
    - env: TOXENV=flake8
      python: 3.5
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
      python: 3.5
    - env: TOXENV=py36-dj20
      python: 3.6
-   - env: TOXENV=py34-dj21
-     python: 3.4
    - env: TOXENV=py35-dj21
      python: 3.5
    - env: TOXENV=py36-dj21

--- a/puput/templates/sitemap.xml
+++ b/puput/templates/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    {% for url in urlset %}
+        <url>
+            <loc>{{ url.location }}</loc>
+            <lastmod>{{ url.lastmod }}</lastmod>
+            <changefreq>{{ url.changefreq }}</changefreq>
+            <priority>{{ url.priority }}</priority>
+        </url>
+    {% endfor %}
+</urlset>

--- a/puput/urls.py
+++ b/puput/urls.py
@@ -1,6 +1,5 @@
 from django.conf import settings
-from django.conf.urls import url, include
-from django.urls import reverse
+from django.urls import reverse, path, include
 
 from .feeds import BlogPageFeed
 from .views import EntryPageServe, EntryPageUpdateCommentsView
@@ -8,28 +7,28 @@ from .utils import strip_prefix_and_ending_slash
 
 
 urlpatterns = [
-    url(
-        regex=r'^entry_page/(?P<entry_page_id>\d+)/update_comments/$',
+    path(
+        route='entry_page/<entry_page_id>/update_comments/',
         view=EntryPageUpdateCommentsView.as_view(),
         name='entry_page_update_comments'
     ),
-    url(
-        regex=r'^(?P<blog_path>[-\w\/]+)/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/(?P<slug>[-\w]+)/$',
+    path(
+        route='<path:blog_path>/<int:year>/<int:month>/<int:day>/<slug:slug>/',
         view=EntryPageServe.as_view(),
         name='entry_page_serve_slug'
     ),
-    url(
-        regex=r'^(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/(?P<slug>[-\w]+)/$',
+    path(
+        route='<int:year>/<int:month>/<int:day>/<slug:slug>/',
         view=EntryPageServe.as_view(),
         name='entry_page_serve'
     ),
-    url(
-        regex=r'^(?P<blog_path>[-\w\/]+)/feed/$',
+    path(
+        route='<path:blog_path>/feed/',
         view=BlogPageFeed(),
         name='blog_page_feed_slug'
     ),
-    url(
-        regex=r'^feed/$',
+    path(
+        route='feed/',
         view=BlogPageFeed(),
         name='blog_page_feed'
     )
@@ -39,28 +38,23 @@ if not getattr(settings, 'PUPUT_AS_PLUGIN', False):
     from wagtail.core import urls as wagtail_urls
     from wagtail.admin import urls as wagtailadmin_urls
     from wagtail.documents import urls as wagtaildocs_urls
-    from wagtail.search import urls as wagtailsearch_urls
     from wagtail.contrib.sitemaps.views import sitemap
 
     urlpatterns.extend([
-        url(
-            regex=r'^blog_admin/',
+        path(
+            route='blog_admin/',
             view=include(wagtailadmin_urls)
         ),
-        url(
-            regex=r'',
+        path(
+            route='',
             view=include(wagtail_urls)
         ),
-        url(
-            regex=r'^search/',
-            view=include(wagtailsearch_urls)
-        ),
-        url(
-            regex=r'^documents/',
+        path(
+            route='documents/',
             view=include(wagtaildocs_urls)
         ),
-        url(
-            regex='^sitemap\.xml$',
+        path(
+            route='sitemap.xml',
             view=sitemap
         )
     ])

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,8 @@ setup(
     long_description=codecs.open(os.path.join(os.path.dirname(__file__), 'README.rst'), encoding='utf-8').read(),
     install_requires=[
         # By default, pick the latest stable version of Django that's officially supported by Wagtail.
-        'Django>=1.11,<2.1.3',
-        'wagtail>=1.0,<=2.3',
+        'Django>=2.0,<2.1.3',
+        'wagtail>=2.0,<=2.3',
         'django-el-pagination>=3.2.4',
         'django-social-share>=1.3.0',
         'django-colorful>=1.3'

--- a/setup.py
+++ b/setup.py
@@ -41,11 +41,11 @@ setup(
     long_description=codecs.open(os.path.join(os.path.dirname(__file__), 'README.rst'), encoding='utf-8').read(),
     install_requires=[
         # By default, pick the latest stable version of Django that's officially supported by Wagtail.
-        'Django>=1.11,<2.1',
-        'wagtail>=1.0,<=2.1',
-        'django-el-pagination>=3.2.1',
-        'django-social-share>=1.1.2',
-        'django-colorful>=1.2'
+        'Django>=1.11,<2.1.3',
+        'wagtail>=1.0,<=2.3',
+        'django-el-pagination>=3.2.4',
+        'django-social-share>=1.3.0',
+        'django-colorful>=1.3'
     ],
     url='http://github.com/APSL/puput',
     author=get_author('puput'),

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
     tapioca-disqus==0.1.2
     gunicorn==19.6.0
 
-    dj20: Django==2.0.10
+    dj20: Django==2.0.9
     dj21: Django>=2.1
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{34,35,36}-dj{111,20}, flake8
+envlist = py{34,35,36}-dj{20,21}, flake8
 
 [flake8]
 max-line-length = 120
@@ -30,7 +30,6 @@ deps =
     tapioca-disqus==0.1.2
     gunicorn==19.6.0
 
-    dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -24,9 +24,9 @@ deps =
     splinter==0.7.5
     pytest==3.0.3
     pytest-splinter==1.7.6
-    django-el-pagination>=3.2.1
-    django-social-share>=1.1.2
-    django-colorful>=1.2
+    django-el-pagination>=3.2.4
+    django-social-share>=1.3.0
+    django-colorful>=1.3
     tapioca-disqus==0.1.2
     gunicorn==19.6.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,8 @@ deps =
     tapioca-disqus==0.1.2
     gunicorn==19.6.0
 
-    dj20: Django>=2.0,<2.1
+    dj20: Django==2.0.10
+    dj21: Django>=2.1
 
 [testenv:flake8]
 basepython = python3.5


### PR DESCRIPTION
Because of [this](https://docs.wagtail.io/en/v2.3/releases/2.0.html#deprecated-search-view) we have to implement our own search backend instead of `wagtail.search` but since we are not using that at all I just got rid of the URL, if that's not the expected change, just let me know so I can implement a search view.