### PR TITLE
Fix entry header image issue in blog page

### DIFF
--- a/puput/templates/puput/blog_page.html
+++ b/puput/templates/puput/blog_page.html
@@ -54,10 +54,12 @@
             <article class="box page-content blog_grid">
                 {% include 'puput/entry_page_header.html' %}
                 <section>
-                    <span class="img-responsive">
-                        {% image entry.header_image fill-800x240 as header_image %}
-                        <img alt="{{ entry.header_image.title }}" src="{{ header_image.url }}">
-                    </span>
+                    {% if entry.header_image %}
+                        <span class="img-responsive">
+                            {% image entry.header_image fill-800x240 as header_image %}
+                            <img alt="{{ entry.header_image.title }}" src="{{ header_image.url }}">
+                        </span>
+                    {% endif %}
                     {% include 'puput/entry_links.html' %}
                 </section>
                 <section class="article">


### PR DESCRIPTION
### Issue summary
When an entry does not have a header image it might display the header image of another entry in the list of entries.

### How to reproduce?
Create an entry without a header image (entry 1), then create a second entry  (entry 2) with a header image. visit blog page, entry 1 will appear with the entry 2 image.

### Explanation
When looping through the entries, and when an entry does not have an image, the template variable "header_image" will not be updated and will keep pointing to the image of the previous entry in the loop, which results in that image appearing in the next entry if it does not have an image.