### PR TITLE
Supporting autogenerated unicode slugs

### DIFF
--- a/puput/urls.py
+++ b/puput/urls.py
@@ -13,12 +13,12 @@ urlpatterns = [
         name='entry_page_update_comments'
     ),
     path(
-        route='<path:blog_path>/<int:year>/<int:month>/<int:day>/<slug:slug>/',
+        route='<path:blog_path>/<int:year>/<int:month>/<int:day>/<str:slug>/',
         view=EntryPageServe.as_view(),
         name='entry_page_serve_slug'
     ),
     path(
-        route='<int:year>/<int:month>/<int:day>/<slug:slug>/',
+        route='<int:year>/<int:month>/<int:day>/<str:slug>/',
         view=EntryPageServe.as_view(),
         name='entry_page_serve'
     ),


### PR DESCRIPTION
As issue #189 states. There is a problem when your blog article includes Non-ASCII characters and Wagtail autogenerates the slug for the blog, it is including it.

Since we were using `<slug:slug>` in our urls, the `slug` converter uses the regex `'[-a-zA-Z0-9_]+'` which doesn't support Non-ASCII character. So, the easiest solution was to just use the `str` converter.