### PR TITLE
related entries: use proper header image

### DIFF
--- a/puput/templates/puput/related_entries.html
+++ b/puput/templates/puput/related_entries.html
@@ -11,8 +11,8 @@
                     <div class="col-md-3">
                         <section class="box feature">
                             <div class="image-related">
-                                {% image entry.header_image fill-800x240 as header_image %}
-                                <img alt="{{ entry.header_image.title }}" src="{{ header_image.url }}">
+                                {% image related_entry.header_image fill-800x240 as header_image %}
+                                <img alt="{{ related_entry.header_image.title }}" src="{{ header_image.url }}">
                             </div>
                             <h3>
                                 <a href="{% entry_url related_entry blog_page %}">{{ related_entry.title }}</a>


### PR DESCRIPTION
Hi,
in related entries the header image is taken from `entry` instead of `related_entry`.