### PR TITLE
remove Python2 compatibility code

### DIFF
--- a/puput/feeds.py
+++ b/puput/feeds.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 from mimetypes import guess_type
-
-from six.moves import urllib_parse
+from urllib.parse import urljoin
 
 from django import http
 from django.contrib.syndication.views import Feed
@@ -17,7 +15,7 @@ class BlogPageFeedGenerator(Rss201rev2Feed):
         super(BlogPageFeedGenerator, self).add_root_elements(handler)
         if self.feed['image_link']:
             handler.addQuickElement(
-                u'image',
+                'image',
                 '',
                 {
                     'url': self.feed['image_link'],
@@ -77,7 +75,7 @@ class BlogPageFeed(Feed):
     def item_enclosure_url(self, item):
         if item.header_image:
             site = Site.find_for_request(self.request)
-            return urllib_parse.urljoin(site.root_url, item.header_image.file.url)
+            return urljoin(site.root_url, item.header_image.file.url)
         return None
 
     def item_enclosure_mime_type(self, item):
@@ -94,7 +92,7 @@ class BlogPageFeed(Feed):
     def _channel_image_link(self):
         if self.blog_page.header_image:
             site = Site.find_for_request(self.request)
-            return urllib_parse.urljoin(site.root_url, self.blog_page.header_image.file.url)
+            return urljoin(site.root_url, self.blog_page.header_image.file.url)
 
     def feed_extra_kwargs(self, obj):
         return {

--- a/puput/models.py
+++ b/puput/models.py
@@ -5,9 +5,8 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.template.defaultfilters import slugify
 from django.utils.translation import ugettext_lazy as _
-from django.utils import six
 
-from wagtail.core.models import Page, PageBase
+from wagtail.core.models import Page
 from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.snippets.models import register_snippet
@@ -209,7 +208,7 @@ def _add_owner_panel():
     return []
 
 
-class EntryPage(six.with_metaclass(PageBase, Entry, Page)):
+class EntryPage(Entry, Page):
     # Search
     search_fields = Page.search_fields + [
         index.SearchField('body'),

--- a/puput/utils.py
+++ b/puput/utils.py
@@ -1,4 +1,3 @@
-from six import string_types
 from importlib import import_module
 from django.urls import reverse
 
@@ -7,7 +6,7 @@ def import_model(path_or_callable):
     if hasattr(path_or_callable, '__call__'):
         return path_or_callable
     else:
-        assert isinstance(path_or_callable, string_types)
+        assert isinstance(path_or_callable, str)
         package, attr = path_or_callable.rsplit('.', 1)
         return getattr(import_module(package), attr)
 


### PR DESCRIPTION
- remove `six` compatibility code 
- remove `EntryPage` metaclass compatibility code
  - in fact remove the metaclass completely since its ancestor (`Page`) has it already