### PR TITLE
add possibility of introducing new comment providers

### DIFF
--- a/docs/comments.rst
+++ b/docs/comments.rst
@@ -4,14 +4,69 @@ Comments
 Puput allows customize the comment system for your blog entries. Simply go to settings tab while editing blog properties
 and add the required parameters depending on which system you want to use.
 
+There is a :code:`PUPUT_COMMENTS_PROVIDER` setting that should point to the specific provider class. It defaults to :class:`DisqusProvider`.
+
 Disqus
 ------
 Set *Disqus api secret* and *Disqus shortname* with your project values and comments will be displayed in each blog entry.
 *Disqus api secret* is needed to retrieve the number of comments of each entry. If you don't need such data
 in your blog just fill *Disqus shortname* field.
 
+In your :file:`settings.py` file:
+
+.. code-block:: python
+
+    PUPUT_COMMENTS_PROVIDER = 'puput.comments.DisqusCommentsProvider'
+
+
 .. note::
 
     If you set *Disqus api secret* you need to install `tapioca-disqus` to access to the Disqus API ::
 
         pip install tapioca-disqus
+
+
+Django Comments
+---------------
+
+Use django comments if you want to store comments in your own database and be able to access them as django models.
+
+In your :file:`settings.py` file:
+
+.. code-block:: python
+
+    PUPUT_COMMENTS_PROVIDER = 'puput.comments.DjangoCommentsCommentsProvider'
+
+
+.. note::
+
+    To use django comments you need to install either::
+
+        pip install django-contrib-comments
+
+    and optionally for features like comment threads, email confirmations, notifications etc::
+
+        pip install django-comments-xtd
+
+Customize comment template
+--------------------------
+
+To change how comments are displayed, subclass the provider class you're using and change its :code:`template`
+method to return the path to your custom template.
+
+Implement your own provider
+---------------------------
+
+To add your own comment provider you will need to subclass :class:`CommentProvider` and implement its methods:
+
+  :code:`template`
+
+return the path to the template used to render the comment section
+
+ :code:`get_context`
+
+return dictionary with data needed in your template
+
+ :code:`get_num_comments`
+
+return number of comments for the entry page

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -34,3 +34,10 @@ PUPUT_USERNAME_REGEX
 
 String setting to define the default author username regex used in routes. Useful for people that are using a custom
 User model.
+
+PUPUT_COMMENTS_PROVIDER
+-----------------------
+
+**Default value:** ``'puput.comments.DisqusCommentsProvider'``
+
+String setting to define the class path for CommentProvider implementation. See :doc:`comments` for more details.

--- a/puput/__init__.py
+++ b/puput/__init__.py
@@ -26,3 +26,5 @@ PUPUT_APPS = (
     # Puput apps
     'puput',
 )
+
+default_app_config = 'puput.apps.PuputAppConfig'

--- a/puput/apps.py
+++ b/puput/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class PuputAppConfig(AppConfig):
+    name = 'puput'
+    verbose_name = 'Puput'
+
+    def ready(self):
+        import puput.signals  # noqa: F401

--- a/puput/comments.py
+++ b/puput/comments.py
@@ -1,14 +1,68 @@
-def get_num_comments_with_disqus(blog_page, entry_page):
-    try:
-        from tapioca.exceptions import ClientError
-        from tapioca_disqus import Disqus
+class CommentProvider:
+    def __init__(self, blog_page, entry_page):
+        self.blog_page = blog_page
+        self.entry_page = entry_page
 
-        disqus_client = Disqus(api_secret=blog_page.disqus_api_secret)
-        try:
-            params = {'forum': blog_page.disqus_shortname, 'thread': 'ident:{}'.format(entry_page.id)}
-            thread = disqus_client.threads_details().get(params=params)
-            return thread.response.posts().data()
-        except ClientError:
+    @property
+    def template(self):
+        raise NotImplementedError()
+
+    def get_context(self):
+        raise NotImplementedError()
+
+    def get_num_comments(self):
+        raise NotImplementedError()
+
+
+class DisqusCommentProvider(CommentProvider):
+
+    @property
+    def template(self):
+        return 'puput/comments/disqus.html'
+
+    def get_context(self):
+        if not self.blog_page.disqus_shortname:
+            return {}
+        return {
+            'disqus_shortname': self.blog_page.disqus_shortname,
+            'disqus_identifier': self.entry_page.id
+        }
+
+    def get_num_comments(self):
+        if not self.blog_page.disqus_api_secret:
             return 0
-    except ImportError:
-        raise Exception('You need to install tapioca-disqus before using Disqus as comment system.')
+        try:
+            from tapioca.exceptions import ClientError
+            from tapioca_disqus import Disqus
+
+            disqus_client = Disqus(api_secret=self.blog_page.disqus_api_secret)
+            try:
+                params = {'forum': self.blog_page.disqus_shortname, 'thread': 'ident:{}'.format(self.entry_page.id)}
+                thread = disqus_client.threads_details().get(params=params)
+                return thread.response.posts().data()
+            except ClientError:
+                return 0
+        except ImportError:
+            raise Exception('You need to install tapioca-disqus before using Disqus as comment system.')
+
+
+class DjangoCommentsProvider(CommentProvider):
+
+    @property
+    def template(self):
+        return 'puput/comments/django_comments.html'
+
+    def get_context(self):
+        return {
+            'entry': self.entry_page
+        }
+
+    def get_num_comments(self):
+        try:
+            from django_comments.models import Comment
+            from django.contrib.contenttypes.models import ContentType
+
+            entry_page_type = ContentType.objects.get(app_label='puput', model='entrypage')
+            return Comment.objects.filter(content_type=entry_page_type, object_pk=self.entry_page.pk).count()
+        except ImportError:
+            raise Exception('You need to install django-comments before using it as comment system.')

--- a/puput/conf/__init__.py
+++ b/puput/conf/__init__.py
@@ -1,0 +1,22 @@
+# borrowed from django_comments_xtd
+
+from django.conf import settings as django_settings
+from django.utils.functional import LazyObject
+
+from puput.conf import defaults as app_settings
+
+
+class LazySettings(LazyObject):
+    def _setup(self):
+        self._wrapped = Settings(app_settings, django_settings)
+
+
+class Settings(object):
+    def __init__(self, *args):
+        for item in args:
+            for attr in dir(item):
+                if attr == attr.upper():
+                    setattr(self, attr, getattr(item, attr))
+
+
+settings = LazySettings()

--- a/puput/conf/defaults.py
+++ b/puput/conf/defaults.py
@@ -1,0 +1,1 @@
+PUPUT_COMMENTS_PROVIDER = 'puput.comments.DisqusCommentsProvider'

--- a/puput/models.py
+++ b/puput/models.py
@@ -225,6 +225,9 @@ class EntryPage(Entry, Page):
     def has_related(self):
         return self.related_entrypage_from.count() > 0
 
+    def get_absolute_url(self):
+        return self.full_url
+
     def get_context(self, request, *args, **kwargs):
         context = super(EntryPage, self).get_context(request, *args, **kwargs)
         context['blog_page'] = self.blog_page

--- a/puput/signals.py
+++ b/puput/signals.py
@@ -1,0 +1,20 @@
+from django.conf import settings
+
+from .utils import import_model
+
+
+def update_comment_count(sender, **kwargs):
+    comment = kwargs['comment']
+    entry_page = comment.content_object
+    comment_class = import_model(settings.PUPUT_COMMENTS_PROVIDER)(entry_page.blog_page, entry_page)
+    num_comments = comment_class.get_num_comments()
+    entry_page.num_comments = num_comments
+    entry_page.save(update_fields=('num_comments',))
+
+
+try:
+    from django_comments_xtd.signals import confirmation_received
+
+    confirmation_received.connect(update_comment_count, dispatch_uid="puput_comment_posted_id")
+except ImportError:
+    pass

--- a/puput/templates/puput/comments/django_comments.html
+++ b/puput/templates/puput/comments/django_comments.html
@@ -1,0 +1,7 @@
+{% load comments %}
+
+<div>
+    <h3>Comments:</h3>
+    {% render_comment_list for entry %}
+    {% render_comment_form for entry %}
+</div>

--- a/puput/views.py
+++ b/puput/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.http import Http404, HttpResponse
 from django.views.generic import View
 from django.views.decorators.csrf import ensure_csrf_cookie
@@ -5,9 +6,8 @@ from django.utils.decorators import method_decorator
 
 from wagtail.core import hooks
 
-from .comments import get_num_comments_with_disqus
 from .models import EntryPage
-from .utils import strip_prefix_and_ending_slash
+from .utils import strip_prefix_and_ending_slash, import_model
 
 
 class EntryPageServe(View):
@@ -55,11 +55,10 @@ class EntryPageUpdateCommentsView(View):
         try:
             entry_page = EntryPage.objects.get(pk=entry_page_id)
             blog_page = entry_page.blog_page
-            num_comments = 0
-            if blog_page.disqus_api_secret:
-                num_comments = get_num_comments_with_disqus(blog_page, entry_page)
+            comment_class = import_model(settings.PUPUT_COMMENTS_PROVIDER)(blog_page, entry_page)
+            num_comments = comment_class.get_num_comments()
             entry_page.num_comments = num_comments
-            entry_page.save()
+            entry_page.save(update_fields=('num_comments',))
             return HttpResponse()
         except EntryPage.DoesNotExist:
             raise Http404


### PR DESCRIPTION
This adds a way to use something other than Disqus (django-comments-xtd, in particular) for comments. I kept all the defaults as disqus, so changes are backward compatible