### PR TITLE
Add example blog to list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,7 @@ Examples of blog sites made with Puput
 * `Body Therapy <http://bodytherapy.ru/blog/>`_
 * `Astro <http://www.mallorcasoft.es/blog/>`_
 * `Kontrabando Film Festival <https://www.kontrabandofilmfestival.org/blog/>`_
+* `IP/DE <https://ipde.com/>`_
 
 Setup
 ~~~~~


### PR DESCRIPTION
Simple update to add a newer example blog to the list. Relates to [issue 227](https://github.com/APSL/puput/issues/227).