### PR TITLE
feat: migrate to wagtail4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Unreleased
+----------
+* Add Wagtail 4 support. Drop Wagtail <3 support.
+* Drop Django <2.2 support.
+* Update requirements-test.
+* Update tox.
+* Fix: include Python 3.10 on setup classifiers.
+
 1.1.4 (2022-12-14)
 ------------------
 * Add Wagtail 3 support.

--- a/puput/abstracts.py
+++ b/puput/abstracts.py
@@ -50,7 +50,7 @@ class BlogAbstract(models.Model):
 
     content_panels = [
         FieldPanel('description', classname="full"),
-        ImageChooserPanel('header_image'),
+        FieldPanel('header_image'),
         FieldPanel('main_color')
     ]
     settings_panels = [
@@ -106,7 +106,7 @@ class EntryAbstract(models.Model):
         MultiFieldPanel(
             [
                 FieldPanel('title', classname="title"),
-                ImageChooserPanel('header_image'),
+                FieldPanel('header_image'),
                 FieldPanel('body', classname="full"),
                 FieldPanel('excerpt', classname="full"),
             ],

--- a/puput/abstracts.py
+++ b/puput/abstracts.py
@@ -4,7 +4,6 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel, InlinePanel, PageChooserPanel
-from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.core.fields import RichTextField
 from modelcluster.contrib.taggit import ClusterTaggableManager
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,6 @@
-pytest==3.0.3
-pytest-splinter==1.7.6
-tox==2.3.1
+pytest==7.1.2
+pytest-django==4.1.0
+requests==2.28.1
+model-bakery==1.5.0
+ipdb==0.13.9
+tox==3.27.1

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
     description='A Django blog app implemented in Wagtail.',
     long_description=codecs.open(os.path.join(os.path.dirname(__file__), 'README.rst'), encoding='utf-8').read(),
     install_requires=[
-        'Django>=2.0,<4.0',
-        'wagtail>=2.7,<4.0',
+        'Django>=3.0,<4.0',
+        'wagtail>=3.0,<5.0',
         'django-el-pagination>=3.2.4',
         'django-social-share>=1.3.0',
         'django-colorful>=1.3'
@@ -38,7 +38,6 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
@@ -48,6 +47,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Operating System :: OS Independent',
         'Topic :: Software Development'
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py{37,38,39,310}-dj{22,30,31,32}, flake8
+envlist = py{37,38,39,310}-dj{30,31,32}, flake8
 
 [gh-actions]
 python =
-    3.7: py37-dj{22,30,31,32}, flake8
-    3.8: py38-dj{22,30,31,32}, flake8
-    3.9: py39-dj{22,30,31,32}, flake8
-    3.10: py310-dj{22,30,31,32}, flake8
+    3.7: py37-dj{30,31,32}, flake8
+    3.8: py38-dj{30,31,32}, flake8
+    3.9: py39-dj{30,31,32}, flake8
+    3.10: py310-dj{30,31,32}, flake8
 
 
 [flake8]
@@ -26,14 +26,12 @@ deps =
     requests==2.28.1
     model-bakery==1.5.0
     ipdb==0.13.9
-    psycopg2-binary==2.9.3
 
     django-el-pagination>=3.2.4
     django-social-share>=1.3.0
     django-colorful>=1.3
     tapioca-disqus==0.1.2
 
-    dj22: Django>=2.2,<3.0
     dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3


### PR DESCRIPTION
* Add Wagtail 4 support. Drop Wagtail <3 support.
* Drop Django <2.2 support.
* Update requirements-test.
* Update tox.
* Fix: include Python 3.10 on setup classifiers.