### PR TITLE
Fix: undo update to django 42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,8 @@ Changelog
 
 Unreleased
 ----------
-* Drop Python <=3.7 support.
-* Add Python 3.11 support.
-* Add Django 4 (up to 4.2) support.
+* Add Python 3.11 support. Drop Python <=3.7 support.
+* Add Django 4 support.
 * Apply black.
 * Update tox.
 * Add markdown to EntryPages.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=[
         'Django>=3.0,<4.2',
         'wagtail>=3.0,<4.2',
-        'django-el-pagination@git+https://github.com/APSL/django-el-pagination.git@4.0.0',
+        'django-el-pagination==4.0.0',
         'django-social-share>=1.3.0',
         'django-colorful>=1.3',
         'wagtail-markdown==0.11.0'

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     description='A Django blog app implemented in Wagtail.',
     long_description=codecs.open(os.path.join(os.path.dirname(__file__), 'README.rst'), encoding='utf-8').read(),
     install_requires=[
-        'Django>=3.0,<4.3',
+        'Django>=3.0,<4.2',
         'wagtail>=3.0,<4.2',
         'django-el-pagination@git+https://github.com/APSL/django-el-pagination.git@4.0.0',
         'django-social-share>=1.3.0',
@@ -44,7 +44,6 @@ setup(
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
-        'Framework :: Django :: 4.2',
         'Intended Audience :: Developers',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py{38,39,310,311}-dj{30,31,32,40,41,42}, flake8, black
+envlist = py{38,39,310,311}-dj{30,31,32,40,41}, flake8, black
 
 [gh-actions]
 python =
-    3.8: py38-dj{30,31,32,40,41,42}, flake8, black
-    3.9: py39-dj{30,31,32,40,41,42}
-    3.10: py310-dj{30,31,32,40,41,42}
-    3.11: py311-dj{30,31,32,40,41,42}
+    3.8: py38-dj{30,31,32,40,41}, flake8, black
+    3.9: py39-dj{30,31,32,40,41}
+    3.10: py310-dj{30,31,32,40,41}
+    3.11: py311-dj{30,31,32,40,41}
 
 
 [flake8]
@@ -37,7 +37,6 @@ deps =
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
-    dj42: Django>=4.2,<4.3
 
 [testenv:flake8]
 basepython = python3.8


### PR DESCRIPTION
Rollback Update to Django 4.2.
Changed naming version for django-el-pagination.