### PR TITLE
feat: add django42 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 * Add Wagtail 5.0 support. Drop Wagtail <=4.0 support.
+* Add Django 4.2 support.
 
 1.2.1 (2023-05-16)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     description='A Django blog app implemented in Wagtail.',
     long_description=codecs.open(os.path.join(os.path.dirname(__file__), 'README.rst'), encoding='utf-8').read(),
     install_requires=[
-        'Django>=3.2,<4.2',
+        'Django>=3.2,<4.3',
         'wagtail>=4.0,<5.1',
         'django-el-pagination==4.0.0',
         'django-social-share>=1.3.0',
@@ -43,6 +43,7 @@ setup(
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
+        'Framework :: Django :: 4.2',
         'Intended Audience :: Developers',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py{38,39,310,311}-dj{32,40,41}, flake8, black
+envlist = py{38,39,310,311}-dj{32,40,41,42}, flake8, black
 
 [gh-actions]
 python =
-    3.8: py38-dj{32,40,41}, flake8, black
-    3.9: py39-dj{32,40,41}
-    3.10: py310-dj{32,40,41}
-    3.11: py311-dj{32,40,41}
+    3.8: py38-dj{32,40,41,42}, flake8, black
+    3.9: py39-dj{32,40,41,42}
+    3.10: py310-dj{32,40,41,42}
+    3.11: py311-dj{32,40,41,42}
 
 
 [flake8]
@@ -35,13 +35,15 @@ deps =
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
+    dj42: Django>=4.2,<4.3
+
 
 [testenv:flake8]
-basepython = python3.8
+basepython = python3.10
 deps = flake8==4.0.1
 commands = flake8 puput tests --exclude=migrations
 
 [testenv:black]
-basepython = python3.8
+basepython = python3.10
 deps = black==22.3.0
 commands = black puput tests -l 120 --check --extend-exclude=/migrations/


### PR DESCRIPTION
Add django4.2 support to Puput.
See below some images to show that Puput can be installed with this Django version

![Captura de pantalla de 2023-06-05 12-23-46](https://github.com/APSL/puput/assets/16468446/06e18e60-1575-4486-8ca0-fb08020de38e)

![Captura de pantalla de 2023-06-05 12-24-59](https://github.com/APSL/puput/assets/16468446/fd73eb9e-ca30-4ff0-88af-5bbe9fddf13e)
![Captura de pantalla de 2023-06-05 12-24-44](https://github.com/APSL/puput/assets/16468446/e5579f2e-cb5f-4449-8366-02d779261cb1)

