### PR TITLE
feat: add wagtail 6 support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,5 @@
 * Yed Podtrzitko
 * Francisco Fernández
 * Pep Lluís Miró
+* Wesley van Lee
+* Marco Badan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+* Add Wagtail 6.1 support. Drop Wagtail <=5.2 support.
+
 
 2.0.0 (2023-07-04)
 ------------------

--- a/puput/__init__.py
+++ b/puput/__init__.py
@@ -15,6 +15,7 @@ PUPUT_APPS = (
     "wagtail.sites",
     "wagtail.contrib.redirects",
     "wagtail.contrib.forms",
+    "wagtail.contrib.search_promotions",
     "wagtail.contrib.sitemaps",
     "wagtail.contrib.routable_page",
     "wagtail",

--- a/puput/routes.py
+++ b/puput/routes.py
@@ -8,7 +8,12 @@ from django.conf import settings
 
 from wagtail.contrib.routable_page.models import RoutablePageMixin, route
 from wagtail.models import Page
-from wagtail.search.models import Query
+import wagtail
+if wagtail.VERSION[:2] < (6, 0):
+    from wagtail.search.models import Query
+else:
+    # https://docs.wagtail.org/en/stable/releases/6.0.html#query-model-moved-to-wagtail-contrib-search-promotions
+    from wagtail.contrib.search_promotions.models import Query
 
 from .utils import get_object_or_None
 

--- a/puput/routes.py
+++ b/puput/routes.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from wagtail.contrib.routable_page.models import RoutablePageMixin, route
 from wagtail.models import Page
 import wagtail
+
 if wagtail.VERSION[:2] < (6, 0):
     from wagtail.search.models import Query
 else:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     description='A Django blog app implemented in Wagtail.',
     long_description=codecs.open(os.path.join(os.path.dirname(__file__), 'README.rst'), encoding='utf-8').read(),
     install_requires=[
-        'wagtail>=5.2',
+        'wagtail>=5.2,<7.0',
         'django-el-pagination==4.0.0',
         'django-taggit>=3.1.0,<4.1',
         'wagtail-markdown==0.11.1'

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,17 @@
 [tox]
 envlist =
-    py{38,39,310}-dj{42}-wt52
-    py311-dj{42,50}-wt52
-    py312-dj{42,50}-wt52
+    py{38,39}-dj{42}-{wt52,60,61}
+    py{310,311,312}-dj{42,50}-wt{52,60,61}
     flake8
     black
 
 [gh-actions]
 python =
-    3.8: py38-dj42-wt52
-    3.9: py38-dj42-wt52
-    3.10: py310-dj{42,50}-wt52
-    3.11: py311-dj{42,50}-wt52
-    3.12: py312-dj{42,50}-wt52, flake8, black
+    3.8: py38-dj42-wt{52,60,61}
+    3.9: py39-dj42-wt{52,60,61}
+    3.10: py310-dj{42,50}-wt{52,60,61}
+    3.11: py311-dj{42,50}-wt{52,60,61}
+    3.12: py312-dj{42,50}-wt{52,60,61}, flake8, black
 
 [flake8]
 max-line-length = 120
@@ -28,7 +27,7 @@ commands =
 deps =
     pytest==8.0.0
     pytest-django==4.8.0
-    requests==2.31.0
+    requests==2.32.0
     model-bakery==1.17.0
     ipdb==0.13.13
     django-el-pagination==4.0


### PR DESCRIPTION
Add wagtail 6 support, only Query model import need to be updated depending on the version.

Everything seems to be working fine:

![Captura de pantalla de 2024-05-22 15-41-25](https://github.com/APSL/puput/assets/16468446/d4b44b9f-e39e-41a7-9af5-29855bf2d8d1)

![Captura de pantalla de 2024-05-22 15-42-56](https://github.com/APSL/puput/assets/16468446/4e27b33b-0ee8-4ad0-8c21-12e665759177)


