### PR TITLE
chore: update requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 Unreleased
 ----------
+* Add Wagtail 6.2 support.
 * EntryPage: auto slug generation from title
  
 2.1.1 (2024-06-25)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=[
         'wagtail>=5.2,<7.0',
         'django-el-pagination==4.0.0',
-        'django-taggit>=3.1.0,<4.1',
+        'django-taggit>=5.0,<5.1',
         'wagtail-markdown==0.11.1'
     ],
     url='http://github.com/APSL/puput',
@@ -41,6 +41,7 @@ setup(
         'Framework :: Django :: 5.0',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 5',
+        'Framework :: Wagtail :: 6',
         'Intended Audience :: Developers',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,17 @@
 [tox]
 envlist =
-    py{38,39}-dj{42}-{wt52,60,61}
-    py{310,311,312}-dj{42,50}-wt{52,60,61}
+    py{38,39}-dj{42}-{wt52,60,61,62}
+    py{310,311,312}-dj{42,50}-wt{52,60,61,62}
     flake8
     black
 
 [gh-actions]
 python =
-    3.8: py38-dj42-wt{52,60,61}
-    3.9: py39-dj42-wt{52,60,61}
-    3.10: py310-dj{42,50}-wt{52,60,61}
-    3.11: py311-dj{42,50}-wt{52,60,61}
-    3.12: py312-dj{42,50}-wt{52,60,61}, flake8, black
+    3.8: py38-dj42-wt{52,60,61,62}
+    3.9: py39-dj42-wt{52,60,61,62}
+    3.10: py310-dj{42,50}-wt{52,60,61,62}
+    3.11: py311-dj{42,50}-wt{52,60,61,62}
+    3.12: py312-dj{42,50}-wt{52,60,61,62}, flake8, black
 
 [flake8]
 max-line-length = 120
@@ -35,6 +35,9 @@ deps =
     dj42: Django>=4.2,<4.3
     dj50: Django>=5.0,<5.1
     wt52: wagtail>=5.2,<5.3
+    wt60: wagtail>=6.0,<6.1
+    wt61: wagtail>=6.1,<6.2
+    wt62: wagtail>=6.2,<6.3
 
 [testenv:flake8]
 basepython = python3.12


### PR DESCRIPTION
Add support to wagtail 6.2 and update django-taggit